### PR TITLE
card width now occupies full width

### DIFF
--- a/src/components/ProjectList/css/project-cards.css
+++ b/src/components/ProjectList/css/project-cards.css
@@ -48,6 +48,7 @@
 .Card-Real-Link:link{
     text-decoration: none;
     color:black;
+    width: 100%;
 }
 .Card-Real-Link:active {
     text-decoration: none;


### PR DESCRIPTION
project card was occupying only the image width, images too small would make card not full witdth.
Card now has 100% width of the parent.