### PR TITLE
add margin 0 auto to center content on cards

### DIFF
--- a/src/components/ProjectList/css/project-cards.css
+++ b/src/components/ProjectList/css/project-cards.css
@@ -39,15 +39,16 @@
 }
 .Card-Real-Link:hover{
     text-decoration: none;
-    color:black;
+    color: black;
 }
 .Card-Real-Link:visited{
     text-decoration: none;
-    color:black;
+    color: black;
 }
 .Card-Real-Link:link{
     text-decoration: none;
     color:black;
+    margin: 0 auto;
 }
 .Card-Real-Link:active {
     text-decoration: none;
@@ -55,12 +56,12 @@
 }
 .Card-Description{
     position: relative;
-    padding:5%;
+    padding: 5%;
 }
 .Card-Link{
     position: relative;
-    padding:10px;
-    color:#0F3CEF;
+    padding: 10px;
+    color: #0F3CEF;
 }
 .Card-Title{
     margin-top: 6%;


### PR DESCRIPTION
Simple CSS fix. Add margin 0 auto on .Card-Real-Link:link to center content on card.