### PR TITLE
#288 Added Techqueria to FirstContributions.io site

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -479,6 +479,13 @@ const projectList = [
     githubLink: 'https://github.com/proot-me/PRoot',
     description: 'chroot, mount --bind, and binfmt_misc without privilege/setup for Linux ',
     tags: ['chroot-environment','userland-exec','rootfs','chroot','c']
+  },
+  {
+    name: 'Techqueria.org',
+    imageSrc: 'https://avatars1.githubusercontent.com/u/17460806?s=200&v=4',
+    githubLink: 'https://github.com/techqueria',
+    description: 'We\'re a community of Latinx professionals in the tech industry.',
+    tags: ['latinx', 'latinx in tech', 'hugo', 'netlify', 'jamstack']
   }
 ];
 export default projectList;


### PR DESCRIPTION
Fixes #288 (https://github.com/techqueria/website/issues/288)

Issue: Techqueria.org was not a part of the https://firstcontributions.github.io/ page. Hence the above issue (#288) was raised.

Solution:
The required details for the card have been added to listOfProjects.js.
This closes an open issue for Techqueria by adding Techqueria.org to the FirstContributions.io site. 

To test:
1. Open https://firstcontributions.github.io/
2. On scrolling down, one of the cards should go by the name of "Techqueria.org" with the description "We're a community of Latinx professionals in the tech industry." along with the tags, image and github link as committed in listOfProjects.js


