### PR TITLE
Coala githubLink updated

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -100,7 +100,7 @@ const projectList = [
   }, {
     name: 'Coala',
     imageSrc: 'https://avatars2.githubusercontent.com/u/10620750?v=3&s=100',
-    githubLink: 'https://coala.io/new',
+    githubLink: 'https://coala.io/newcomer',
     description: 'Unified command-line interface for linting and fixing all your code.',
     tags: ['UX', 'Linter', 'Python'],
   }, {


### PR DESCRIPTION
Coala link was broken while navigating the project list. 

From Coala's [Get Involved](https://coala.io/#/getinvolved?lang=Python) page, the project is now directing newcomers to navigate to their [newcomer guide](https://coala.io/newcomer) through this link. 