### PR TITLE
Fix GitHub link for Roc

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -525,7 +525,7 @@ const projectList = [
   {
     name: 'Roc',
     imageSrc: 'https://roc-project.github.io/icon.png',
-    githubLink: 'https://github.com/roc-project/roc/contribute',
+    githubLink: 'https://github.com/roc-project/roc/labels/help%20wanted',
     description: 'A toolkit for real-time audio streaming over the network',
     tags: ['C++', 'Audio', 'Streaming', 'Networking', 'Cross-Platform', 'Linux', 'MacOS', 'Windows']
   },


### PR DESCRIPTION
The `/contribute` link, introduced by #58, is incorrect. It does not show expected issues, likely because Roc doesn't use the `good first issue` tag.

See also: #57.