### PR TITLE
Update links to Roc

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -516,9 +516,9 @@ const projectList = [
     tags: ['JavaScript', 'server-rendering', 'node', 'nextjs', 'react']
   },
   {
-    name: 'Roc',
-    imageSrc: 'https://roc-project.github.io/icon.png',
-    projectLink: 'https://github.com/roc-project/roc/labels/help%20wanted',
+    name: 'Roc Toolkit',
+    imageSrc: 'https://roc-streaming.org/icon.png',
+    projectLink: 'https://github.com/roc-streaming/roc-toolkit/labels/help%20wanted',
     description: 'A toolkit for real-time audio streaming over the network',
     tags: ['C++', 'Audio', 'Streaming', 'Networking', 'Cross-Platform', 'Linux', 'MacOS', 'Windows']
   },


### PR DESCRIPTION
"Roc" was renamed to "Roc Toolkit", this PR updates the name and links.