### PR TITLE
Add project Eclipse JKube

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -824,6 +824,13 @@ const projectList = [
     projectLink: 'https://github.com/simple-icons/simple-icons',
     description: 'SVG icons for popular brands',
     tags: ['JavaScript', 'OpenSource', 'Beginner', 'SVG', 'NodeJS']
+  },
+  {
+    name: 'Eclipse JKube',
+    imageSrc: 'https://github.com/eclipse/jkube/raw/master/media/JKube-Logo-final-square-color.png',
+    projectLink: 'https://github.com/eclipse/jkube',
+    description: 'Cloud-Native Java Applications without a hassle, bring your Java applications to Kubernetes',
+    tags: ['Java', 'Kubernetes', 'OpenShift', 'Eclipse', 'OpenSource', 'Beginner']
   }
 ];
 export default projectList;


### PR DESCRIPTION
Add [Eclipse JKube](https://www.eclipse.org/jkube/) to the project list.

Specially crafted issues for beginners and first time committers to the project are labeled [first-timers-only](https://github.com/eclipse/jkube/labels/first-timers-only).

Preview:
![Screenshot from 2021-06-23 11-49-06](https://user-images.githubusercontent.com/488391/123076049-0f3f2700-d419-11eb-9c06-37ec4913ebde.png)
