### PR TITLE
Opens project card links in new tab

### DIFF
--- a/src/components/ProjectList/ProjectsCards.jsx
+++ b/src/components/ProjectList/ProjectsCards.jsx
@@ -20,7 +20,7 @@ const Card = ({
 
   return (
     <div className="Card-Container">
-      <a className="Card-Real-Link" href={projectLink}>
+      <a className="Card-Real-Link" href={projectLink} target="_blank">
         <div className="Card-Header">
           <img
             className="Project-Logo"


### PR DESCRIPTION

As a brand new contributor using this application to search for a project to which I could contribute, I noticed that I had to click through multiple project links in order to find a project to which I felt I was able to contribute. I quickly noticed that my search would be aided by launching the project link in a new tab rather than having to navigate back to the application page in order to find a new link. 

This commit adds a _blank target for the anchor tag within the Project Card component to aid in this issue. 