### PR TITLE
Moved index.css to containers folder

### DIFF
--- a/src/containers/index.css
+++ b/src/containers/index.css
@@ -1,0 +1,5 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: sans-serif;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
-import './index.css';
+import './containers/index.css';
 
 ReactDOM.render(
   <App />,


### PR DESCRIPTION
Hello everyone, this is my first contribution.
I have moved index.css to containers folder but could not move index.js as yarn start could not find index.js in src folder.
Maybe command 'react-scripts start' is designed in such way.
Is there any way that 'react-scripts start' command check for index.js in src/containers folder.

Here is a screenshot for reference.
![Screenshot_20220922_110003](https://user-images.githubusercontent.com/96711588/191665697-08ae60f1-5780-48c5-acf2-d3d339bbcccc.png)

