### PR TITLE
Add Scribe-iOS to listOfProjects.js

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1132,6 +1132,13 @@ const projectList = [
     projectLink: 'https://github.com/codenameone/CodenameOne',
     description: 'Cross-platform mobile app development framework for Java & Kotlin developers',
     tags: ['Cross-Platform', 'OpenSource', 'Java', 'Kotlin', 'Android', 'iOS', 'Framework']
+  },
+    {
+    name: 'Scribe - Language Keyboards',
+    imageSrc: 'https://raw.githubusercontent.com/scribe-org/Organization/main/logo/ScribeAppLogo.png',
+    projectLink: 'https://github.com/scribe-org/Scribe-iOS',
+    description: 'Keyboards for language learners with translation, verb conjugation and more!',
+    tags: ['iOS', 'Swift', 'Productivity', 'Good First Issue', 'Beginner']
   }
 ];
 export default projectList;


### PR DESCRIPTION
Hi there! 

Hoping that we can be added to this list. Scribe is still relatively new, but we're slowly making headway towards v2.0 that adds autocomplete and autosuggest - the last two must have features for a wider audience. The app's data is mostly from [Wikidata](https://www.wikidata.org/wiki/Wikidata:Main_Page) and Wikipedia, and we're a [featured project](https://www.mediawiki.org/wiki/New_Developers) for developers who are new to Wikimedia :) 

Hope that everything's in order for the PR, and thanks for this list!