### PR TITLE
remove archived github.com repo

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1028,15 +1028,6 @@ const projectList = [
     tags: ['OpenSource', 'React', 'Javascript', 'Beginner', 'Productivity'],
   },
   {
-    name: 'Rocky Linux',
-    imageSrc:
-      'https://raw.githubusercontent.com/rocky-linux/rocky-logos/main/icons/hicolor/256x256/apps/system-logo-icon.png',
-    projectLink: 'https://github.com/rocky-linux/rocky#contributing',
-    description:
-      'Rocky Linux is a community enterprise Operating System designed to be 100% bug-for-bug compatible with Enterprise Linux, now that CentOS has shifted direction.',
-    tags: ['OpenSource', 'Shell', 'Python', 'HTML', 'Ansible', 'Linux'],
-  },
-  {
     name: 'Phpmyadmin',
     imageSrc:
       'https://raw.githubusercontent.com/phpmyadmin/phpmyadmin/master/themes/original/img/logo_right.png',


### PR DESCRIPTION
another PR for #258 

---

The [**Rocky Linux** project][2] is archived on Github.com, but remains an [active project elsewhere][3].

I'd argue that **Rocky Linux** is not a great project for First Contributions, since it requires quite a [sign-up process][1] and they state (on their archived github.com project), "We do not currently have any official crowdsourcing established." 

[1]: https://wiki.rockylinux.org/contributing/start/
[2]: https://github.com/rocky-linux/rocky#contributing
[3]: https://wiki.rockylinux.org/contributing/