### PR TITLE
Update Scribe imageSrc in listOfProjects.js

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1148,7 +1148,7 @@ const projectList = [
     },
   {
     name: 'Scribe - Language Keyboards',
-    imageSrc: 'https://raw.githubusercontent.com/scribe-org/Organization/main/logo/ScribeIcon1024Rounded.png',
+    imageSrc: 'https://raw.githubusercontent.com/scribe-org/Organization/main/icon/ScribeIcon1024Rounded.png',
     projectLink: 'https://github.com/scribe-org/Scribe-iOS',
     description: 'Keyboards for language learners with translation, verb conjugation and more!',
     tags: ['iOS', 'Swift', 'Productivity', 'Good First Issue', 'Beginner']

--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1148,7 +1148,7 @@ const projectList = [
     },
   {
     name: 'Scribe - Language Keyboards',
-    imageSrc: 'https://raw.githubusercontent.com/scribe-org/Organization/main/logo/ScribeAppLogo.png',
+    imageSrc: 'https://raw.githubusercontent.com/scribe-org/Organization/main/logo/ScribeIcon1024Rounded.png',
     projectLink: 'https://github.com/scribe-org/Scribe-iOS',
     description: 'Keyboards for language learners with translation, verb conjugation and more!',
     tags: ['iOS', 'Swift', 'Productivity', 'Good First Issue', 'Beginner']


### PR DESCRIPTION
I've been updating the images for the repos and renamed the one that's referenced here. I think that doing the rounded icon would be best for the site anyway :)

Want to thank you again, btw! Looking at the traffic for Scribe, most of the external traffic is coming from firstcontributions.github.io 😊