### PR TITLE
Added Daml to the list of projects

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1188,5 +1188,12 @@ const projectList = [
     description: 'learn easily and quickly',
     tags: ['go']
   },
+  {
+    name: 'Daml',
+    imageSrc: 'https://raw.githubusercontent.com/digital-asset/daml/main/daml-logo.png',
+    projectLink: 'https://github.com/digital-asset/daml/contribute',
+    description: 'Daml is an open-source smart contract language for building future-proof distributed applications on a safe, privacy-aware runtime.',
+    tags: ['Scala','Haskell']
+  },
 ];
 export default projectList;


### PR DESCRIPTION
Adding the open source Apache-2.0 project [Daml](https://github.com/digital-asset/daml) to the list of projects.
Addresses #1 .