### PR TITLE
update image url

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1027,11 +1027,11 @@ const projectList = [
     tags: ['OpenSource', 'React', 'Javascript', 'Beginner', 'Productivity'],
   },
   {
-    name: 'Phpmyadmin',
+    name: 'PhpMyAdmin',
     imageSrc:
-      'https://raw.githubusercontent.com/phpmyadmin/phpmyadmin/master/themes/original/img/logo_right.png',
+      'https://avatars.githubusercontent.com/u/1351977?s=200&v=4',
     projectLink: 'https://www.phpmyadmin.net/contribute/',
-    description: 'A web interface for MySQL and MariaDB.',
+    description: 'Handle the administration of MySQL over the web, supports wide range of operations on MySQL and MariaDB.',
     tags: ['OpenSource', 'Mariadb', 'Mysql', 'HTML', 'PHP', 'Javascript'],
   },
   {


### PR DESCRIPTION
I came across to this website of [First Contributors](https://firstcontributions.github.io/), I'd like the UI.

I added this image [URL](https://avatars.githubusercontent.com/u/1351977?s=200&v=4) in your [project list](https://github.com/firstcontributions/firstcontributions.github.io/blob/source/src/components/ProjectList/listOfProjects.js) used from [Phpmyadmin](https://github.com/phpmyadmin) present at GitHub Org. The previous image [URL](https://raw.githubusercontent.com/phpmyadmin/phpmyadmin/master/themes/original/img/logo_right.png) wasn't there anymore.

[PhpMyAdmin](https://www.phpmyadmin.net/) Website UI has changed with new release notes in 2023 at it's official website.