### PR TITLE
Fix The "Get started" button link redirection #255

### DIFF
--- a/src/components/LinkButton/LinkButton.jsx
+++ b/src/components/LinkButton/LinkButton.jsx
@@ -8,7 +8,7 @@ class LinkButton extends Component {
       <div className="LinkButton-Wrapper">
         <a
           className="LinkButton"
-          href="https://github.com/firstcontributions/first-contributions/blob/master/README.md"
+          href="https://github.com/firstcontributions/first-contributions/blob/main/README.md"
         >
           <span> Get started </span>
         </a>

--- a/src/components/LinkButton/__snapshots__/LinkButton.test.js.snap
+++ b/src/components/LinkButton/__snapshots__/LinkButton.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders a project card 1`] = `
 <a
   className="LinkButton"
-  href="https://github.com/firstcontributions/first-contributions/blob/master/README.md"
+  href="https://github.com/firstcontributions/first-contributions/blob/main/README.md"
 >
   <span>
      Get started 


### PR DESCRIPTION
I change the url of the button 'Get started' that point to the 'master' branch to other that point to 'main' branch fixing the redirect issue

fix issue #255
