### PR TITLE
Add attribute target=blank to card link

### DIFF
--- a/src/components/ProjectList/ProjectsCards.jsx
+++ b/src/components/ProjectList/ProjectsCards.jsx
@@ -20,7 +20,7 @@ const Card = ({
 
   return (
     <div className="Card-Container">
-      <a className="Card-Real-Link" href={projectLink}>
+      <a className="Card-Real-Link" href={projectLink} target='blank'>
         <div className="Card-Header">
           <img
             className="Project-Logo"


### PR DESCRIPTION
Prior, the link redirects to the location of the link on the same tab as the homepage of https://firstcontributions.github.io. This modification adds <a target='blank'> to the card link and now enables the link to open another tab for the location the link redirects to preseving the tab of https://firstcontributions.github.io