### PR TITLE
fix: removed outdated atom project.

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1,5 +1,5 @@
 const projectList = [
-  
+
   {
     name: "appsmith",
     imageSrc: "https://raw.githubusercontent.com/appsmithorg/appsmith/release/static/appsmith_logo_white.png",
@@ -457,22 +457,6 @@ const projectList = [
     description:
       "A generic JSON document store with sharing and synchronisation capabilities.",
     tags: ["Python", "API", "HTTP", "Web", "Decentralisation"],
-  },
-  {
-    name: "atom",
-    imageSrc:
-      "https://upload.wikimedia.org/wikipedia/commons/e/e2/Atom_1.0_icon.png",
-    projectLink: "https://github.com/atom/atom/",
-    description: "A customizable text editor built on electron.",
-    tags: [
-      "Atom",
-      "Editor",
-      "Javascript",
-      "Electron",
-      "Windows",
-      "Linux",
-      "Macos",
-    ],
   },
   {
     name: "OpenGenus",


### PR DESCRIPTION
**Pull Request Description:**

This pull request aims to address issue #362 by removing an outdated project entry from the project suggestions list.

**Proposed Changes:**
- Removed the outdated Atom project from the list of project suggestions.

Upon reviewing the `listOfProjects.js` file, I noticed that the Atom project no longer receives significant updates and is not actively maintained. Therefore, it is advisable to remove it from the project suggestions to provide contributors with up-to-date recommendations.

This pull request removes the following entry from the list:

```javascript
  {
    name: "atom",
    imageSrc:
      "https://upload.wikimedia.org/wikipedia/commons/e/e2/Atom_1.0_icon.png",
    projectLink: "https://github.com/atom/atom/",
    description: "A customizable text editor built on electron.",
    tags: [
      "Atom",
      "Editor",
      "Javascript",
      "Electron",
      "Windows",
      "Linux",
      "Macos",
    ],
  },
```

Considering the lack of recent updates, this removal will help maintain the accuracy and relevancy of the project suggestions list, ensuring that contributors find actively maintained projects.

I kindly request a thorough review of this pull request to verify the changes and merge them into the main branch to enhance the quality of the project suggestions.

Thank you for your attention!

**Addresses:** #362