### PR TITLE
add page meta description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Web app for First Contributors. Find a repo to contribute to today! ">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <!--


### PR DESCRIPTION
There is another Lighthouse SEO issue that is currently not addressable due to elements nested in an `<a>` making it uncrawlable. 