### PR TITLE
fix: link target _blank

### DIFF
--- a/src/components/ProjectList/ProjectsCards.jsx
+++ b/src/components/ProjectList/ProjectsCards.jsx
@@ -20,7 +20,7 @@ const Card = ({
 
   return (
     <div className="Card-Container">
-      <a className="Card-Real-Link" href={projectLink} target='blank'>
+      <a className="Card-Real-Link" href={projectLink} target='_blank'>
         <div className="Card-Header">
           <img
             className="Project-Logo"


### PR DESCRIPTION
`target="blank"` is not the same as `target="_blank"`
The old solution will result in multiple projects clicked going to the exact same tab effectively overwriting it. The new solution will open each clicked link in new tabs. 