### PR TITLE
[UI Enhancement]: Updated the 'Get started' button on home page

### DIFF
--- a/src/components/LinkButton/LinkButton.css
+++ b/src/components/LinkButton/LinkButton.css
@@ -9,8 +9,10 @@
   border-radius: 2px;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
 
-  background-color:  #0A680D;
-  color: #fff;
+  background-color:  #fff;
+  color: #0054B5;
+  border-radius: 5px;
+  border: solid 2px #fff;
 
   -webkit-transition: background-color 0.3s;
   -moz-transition: background-color 0.3s;
@@ -19,7 +21,9 @@
 }
 
 .LinkButton:hover {
-  background-color: #26a65b;
+  background-color: #0054B5;
+  border: solid 2px #fff;
+  color: #fff;
 }
 
 .LinkButton > span {


### PR DESCRIPTION
## What does this PR do? 
- The background color of the button 'Get started' on home page is changed to <b> white </b> from <b> green </b>.
- Addresses #371 
- Enhanced UI by changing button color, adding border radius and good hover effect.

## Screenshots:
See the enhanced 'Get started' button:
![White Button](https://github.com/firstcontributions/firstcontributions.github.io/assets/88813886/da311713-2218-4de3-9346-3929f5d536d8)
'Get started' button on hover:
![on-hover](https://github.com/firstcontributions/firstcontributions.github.io/assets/88813886/82ce4b5d-56cf-4486-ba17-d4573314638f)

