### PR TITLE
fixed navbar icon shuttering issue

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -2,6 +2,7 @@
     background-color: #0054B5;
     overflow: hidden;
     text-align: right;
+    padding: 20px 0;
 }
 @media (max-width: 700px) {
     .topnav {
@@ -10,7 +11,7 @@
 }
 
 .topnav a {
-    display: inline-block;
+    display: inline;
     color: #f2f2f2;
     text-align: center;
     padding: 20px 15px;


### PR DESCRIPTION
Addresses the issue #220

The problem is display property of anchor tag is changing from inline-block to inline when hovered.
I have fixed by changing,
-Added the padding for navbar to have same height as before
-Changed the display property of anchor tag to inline