### PR TITLE
Fixed Missing href Attribute in <a> Tag for Project Card->{aprenda-go-com-testes} #416

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1298,7 +1298,7 @@ const projectList = [
     name: "aprenda-go-com-testes",
     imageSrc:
       "https://github.com/larien/aprenda-go-com-testes/blob/main/.gitbook/assets/red-green-blue-gophers-smaller.png",
-    githubLink: "https://github.com/larien/aprenda-go-com-testes",
+    projectLink: "https://github.com/larien/aprenda-go-com-testes",
     description: "learn easily and quickly",
     tags: ["go"],
   },


### PR DESCRIPTION
There was githubLink instead of projectLink in [here].(https://github.com/firstcontributions/firstcontributions.github.io/blob/source/src/components/ProjectList/listOfProjects.js)