### PR TITLE
Add Scribe-Android to listOfProjects.js

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1253,13 +1253,22 @@ const projectList = [
     tags: ["JavaScript", "Package-Manager", "NodeJS", "NPM"],
   },
   {
-    name: "Scribe - Language Keyboards",
+    name: "Scribe-iOS",
     imageSrc:
       "https://raw.githubusercontent.com/scribe-org/Organization/main/icon/ScribeIcon1024Rounded.png",
     projectLink: "https://github.com/scribe-org/Scribe-iOS",
     description:
-      "Keyboards for language learners with translation, verb conjugation and more!",
-    tags: ["iOS", "Swift", "Productivity", "Good First Issue", "Beginner"],
+      "iOS keyboards for language learners with translation, verb conjugation and more!",
+    tags: ["iOS", "Swift", "Education", "Good First Issue", "Beginner"],
+  },
+  {
+    name: "Scribe-Android",
+    imageSrc:
+      "https://raw.githubusercontent.com/scribe-org/Organization/main/icon/ScribeIcon1024Rounded.png",
+    projectLink: "https://github.com/scribe-org/Scribe-Android",
+    description:
+      "Android keyboards for language learners with translation, verb conjugation and more!",
+    tags: ["Android", "Kotlin", "Education", "Good First Issue", "Beginner"],
   },
   {
     name: "mindsdb",


### PR DESCRIPTION
Hey @Roshanjossey 👋

Sending along the Android version of the iOS app Scribe - Language Keyboard, which is already on here. The [Scribe](https://github.com/scribe-org) community is a [Wikimedia project for new developers](https://www.mediawiki.org/wiki/New_Developers#Scribe) that's been growing recently :) We have tons of [good first issues](https://github.com/scribe-org/Scribe-Android/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) now for the Android app, and it'd be great if we could get your all's support with contributor acquisition! This PR also updates the Scribe-iOS entry so the projects are distinct 😊

Note that we're currently working on an MVP for Scribe-Android right now, so it's totally fine if you'd prefer me to send this along when we've finished the first release. Also let me know if you'd prefer me to just combine the entries and add an Android and Kotlin tag to the existing entry :)

Hope all's well with you! 😊