### PR TITLE
 ProjectLink in aprenda-go-com-testes

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -1297,9 +1297,10 @@ const projectList = [
   {
     name: "aprenda-go-com-testes",
     imageSrc:
-      "https://github.com/larien/aprenda-go-com-testes/blob/main/.gitbook/assets/red-green-blue-gophers-smaller.png",
-    githubLink: "https://github.com/larien/aprenda-go-com-testes",
-    description: "learn easily and quickly",
+      "https://raw.githubusercontent.com/larien/aprenda-go-com-testes/refs/heads/main/.gitbook/assets/red-green-blue-gophers-smaller.png",
+    projectLink: "https://github.com/cassio645/aprenda-go-com-testes",
+    description:
+      "learn easily and quickly",
     tags: ["go"],
   },
   {


### PR DESCRIPTION
The link is expired. so, I have Updated the working URL and Image in ListOfProject.js file. Now it's working as expected.
**1. Before Fix:**
![image](https://github.com/user-attachments/assets/7f353a96-e866-4393-9030-69d6281655cf)


**2. After fix:**
![image](https://github.com/user-attachments/assets/427fa070-731d-452f-95f6-ba5815f22349)
