### PR TITLE
Removed atom

### DIFF
--- a/src/components/ProjectList/listOfProjects.js
+++ b/src/components/ProjectList/listOfProjects.js
@@ -482,22 +482,6 @@ const projectList = [
     tags: ["Python", "API", "HTTP", "Web", "Decentralisation"],
   },
   {
-    name: "atom",
-    imageSrc:
-      "https://upload.wikimedia.org/wikipedia/commons/e/e2/Atom_1.0_icon.png",
-    projectLink: "https://github.com/atom/atom/",
-    description: "A customizable text editor built on electron.",
-    tags: [
-      "Atom",
-      "Editor",
-      "Javascript",
-      "Electron",
-      "Windows",
-      "Linux",
-      "Macos",
-    ],
-  },
-  {
     name: "OpenGenus",
     imageSrc:
       "https://raw.githubusercontent.com/notnerb/FamilySite/master/logo.png",


### PR DESCRIPTION
This change removes the Atom project as the editor is no longer in active development and the repository has been archived since March 2023