### PR TITLE
fix: connect CSS file properly to index.html for correct styling

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -2,4 +2,8 @@ body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
+ 
 }
+/* .head {
+  color: rebeccapurple;   for testing
+} */

--- a/public/index.html
+++ b/public/index.html
@@ -5,19 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-  <!--
+ <link rel="stylesheet" href="index.css">
+ <!--
   Notice the use of %PUBLIC_URL% in the tag above.
   It will be replaced with the URL of the `public` folder during the build.
   Only files inside the `public` folder can be referenced from the HTML.
-
+ 
   Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
   work correctly both with client-side routing and a non-root public URL.
   Learn how to configure a non-root public URL by running `npm run build`.
-  -->
+ -->
   <title>First Contributions</title>
 </head>
 <body>
 <div id="root"></div>
+<h1 class="head">hii</h1>
 <!--
 This HTML file is a template.
 If you open it directly in the browser, you will see an empty page.


### PR DESCRIPTION
This PR fixes issue #97162 by correcting the CSS file path in index.html. 
The missing stylesheet is now properly linked, and styles are correctly applied.
