### PR TITLE
bug:removed coala as its not working

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -288,14 +288,6 @@ export const projectList = [
     tags: ["PowerShell", "Shell", "Cross Platform"],
   },
   {
-    name: "Coala",
-    imageSrc: "https://avatars2.githubusercontent.com/u/10620750?v=3&s=100",
-    projectLink: "https://coala.io/newcomer",
-    description:
-      "Unified command-line interface for linting and fixing all your code.",
-    tags: ["Python", "Linting", "Code Quality"],
-  },
-  {
     name: "Webpack",
     imageSrc: "https://avatars3.githubusercontent.com/u/2105791?v=3&s=100",
     projectLink: "https://github.com/webpack/webpack/contribute",


### PR DESCRIPTION
#508 
the link mentioned for coala is not working or being maintained and is redirecting to some third party website
<img width="1758" height="1027" alt="Screenshot 2025-10-05 125335" src="https://github.com/user-attachments/assets/e7fe7062-d038-4a38-92c6-792fcd8d3fd2" />
<img width="919" height="195" alt="Screenshot 2025-10-05 125303" src="https://github.com/user-attachments/assets/d2e23dd6-ba27-49a1-87f7-8e8f51027fa9" />
