### PR TITLE
Fix project link for aprenda-go-com-testes card

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1300,7 +1300,6 @@ export const projectList = [
     projectLink: "https://github.com/larien/aprenda-go-com-testes",
     imageSrc:
       "https://raw.githubusercontent.com/larien/aprenda-go-com-testes/refs/heads/main/.gitbook/assets/red-green-blue-gophers-smaller.png",
-    projectLink: "https://github.com/cassio645/aprenda-go-com-testes",
     description: "learn easily and quickly",
     tags: ["go"],
   },


### PR DESCRIPTION
Addresses #287

- Fixed missing projectLink for aprenda-go-com-testes project
- Verified locally that clicking the card redirects to the correct GitHub repository
