### PR TITLE
fix: remove expired Slack link from Navbar (closes #111088)

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,22 +3,19 @@
 ---
 
 <div class="topnav">
-  <a href="https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w" target="_blank" rel="noopener noreferrer">
-    <img src="/slack.svg" class="logo" alt="slack logo" />
-    <span>Slack</span>
-  </a>
-  <a href="https://www.youtube.com/channel/UCMXNFxCvyH5LhUwEcmY8qGQ" target="_blank" rel="noopener noreferrer">
+ <a href="https://www.youtube.com/channel/UCMXNFxCvyH5LhUwEcmY8qGQ" target="_blank" rel="noopener noreferrer">
     <img src="/youtube.svg" class="logo" alt="youtube logo" />
     <span>Youtube</span>    
-  </a>
-  <a href="https://twitter.com/1stContribution" target="_blank" rel="noopener noreferrer">
+</a>
+<a href="https://twitter.com/1stContribution" target="_blank" rel="noopener noreferrer">
     <img src="/twitter.svg" class="logo" alt="twitter logo" />
     <span>Twitter</span>
-  </a>
-  <a href="https://github.com/firstcontributions/first-contributions" target="_blank" rel="noopener noreferrer">
+</a>
+<a href="https://github.com/firstcontributions/first-contributions" target="_blank" rel="noopener noreferrer">
     <img src="/github.svg" class="logo" alt="github logo" />
     <span>GitHub</span>
-  </a>
+</a>
+
 </div>
 
 <style>

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1001,7 +1001,7 @@ export const projectList = [
     imageSrc:
       "https://raw.githubusercontent.com/mattermost/mattermost-handbook/3b54c2cd1f823d1ea012ce45d1baa61fb4fbedbc/.gitbook/assets/branding/logo-downloads/mattermost-logo-vertical-blue.png",
     projectLink: "https://github.com/mattermost/mattermost-server/contribute",
-    description: "Open source Slack-alternative for DevOps teams",
+    description: "Open source-alternative for DevOps teams",
     tags: ["Go", "Javascript", "React", "React Native"],
   },
   {

--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -191,7 +191,7 @@
             structure and coding style.
           </li>
           <li>
-            Join the Community: Participate in discussions on forums, Slack, or
+            Join the Community: Participate in discussions on forums, or
             Discord to get a feel for the community.
           </li>
         </ul>


### PR DESCRIPTION
Removed the expired Slack link from the top navigation as discussed in issue #111088.
The YouTube, Twitter, and GitHub links remain unchanged. 
If a new active Slack link is available, I can update it in a future PR instead of removing it.
