### PR TITLE
Fixed Card Clicking

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -14,7 +14,7 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
 ---
 
 <div class="Card-Container">
-  <a class="Card-Real-Link" href={projectLink} target="_blank">
+  <div class="Card-Real-Link">
     <div class="Card-Header">
       <img
         class="Project-Logo"
@@ -41,10 +41,10 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
         <IssueList projectLink={projectLink} projectName={name} />
       )}
     </div>
-    <div class="Card-Link">
+    <a class="Card-Link" href={projectLink} target="_blank" rel="noopener noreferrer">
       <span>Go to Project</span>
-    </div>
-  </a>
+    </a>
+  </div>
 </div>
 
 <style>
@@ -157,6 +157,9 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
 
 
   .Card-Link {
+    display: block;
+    text-decoration: none;
+    cursor: pointer;
     background: linear-gradient(135deg, rgba(102, 126, 234, 0.8) 0%, rgba(118, 75, 162, 0.8) 100%);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);


### PR DESCRIPTION
Bug cause - 
Those cards render Issue List, which contains issue links (<a> tags).
ProjectCard was also wrapping the entire card in an outer <a>, creating nested anchors (invalid HTML). Browsers handle this unpredictably, which caused the button area to lose proper pointer/link behavior.
Fix implemented - 
Removed the outer card-level anchor wrapper.
Kept card content inside a non-link container.
Made “Go to Project” a standalone anchor with:
href={projectLink}
target="_blank"
rel="noopener noreferrer"
Added explicit button-link styles (display: block, text-decoration: none, cursor: pointer) to preserve expected UX.
Result - 
The “Go to Project” button now behaves consistently as a clickable link across all cards, including those with embedded issue links.