### PR TITLE
fix: add pointer-events none to Card-Link pseudo-element to fix click

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -182,6 +182,7 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     background: linear-gradient(135deg, rgba(102, 126, 234, 0.9) 0%, rgba(118, 75, 162, 0.9) 100%);
     opacity: 0;
     transition: opacity 0.3s ease;
+    pointer-events: none;
   }
 
   .Card-Link:hover::before {


### PR DESCRIPTION
## Bug Fix: "Go to Project" button not clickable

### Problem
The "Go to Project" button on project cards was unresponsive to clicks on hover. Users couldn't navigate to project pages by clicking the button.

### Root Cause
The `.Card-Link::before` CSS pseudo-element creates a gradient overlay on hover, but it was missing `pointer-events: none`. This caused the overlay to sit on top of the `<a>` link and intercept all click events.

### Fix
Added `pointer-events: none` to `.Card-Link::before` in [ProjectCard.astro](cci:7://file:///c:/Users/hamza/OneDrive/Desktop/TOP%20IMPORTANT%20FOLDER/learnig%20folder/firstcontributions.github.io/src/components/ProjectCard.astro:0:0-0:0) so clicks pass through the overlay to the actual link underneath.

### Testing
Verified locally on the Astro dev server — buttons are now fully clickable and correctly navigate to project URLs.
