### PR TITLE
fix: resolve Astro tsconfig extends path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "astro/tsconfigs/strict",
+  "extends": "./node_modules/astro/tsconfigs/strict.json",
   "include": [
     ".astro/types.d.ts",
     "**/*"


### PR DESCRIPTION
This PR fixes a local TypeScript configuration issue that was showing false errors in the editor when trying to resolve Astro’s base config.

I updated the config reference so the project resolves correctly in this environment, then verified everything by installing dependencies and running the development server.

There are no functional or UI changes in this PR.
It only improves developer experience by removing misleading configuration errors.