### PR TITLE
Add Astro to project list

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1458,4 +1458,11 @@ export const projectList = [
     description: "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
     tags: ["Python", "Automation", "Configuration Management"],
   },
+  {
+    name: "Astro",
+    imageSrc: "https://avatars.githubusercontent.com/u/44914786?s=200&v=4",
+    projectLink: "https://github.com/withastro/astro/contribute",
+    description: "Astro is a web framework for building fast content-driven websites, blogs, marketing pages, and documentation sites.",
+    tags: ["JavaScript", "TypeScript", "Frontend", "Static Site Generator"],
+  },
 ];


### PR DESCRIPTION
## Summary
- Add Astro to the open source project list with its contribution page and relevant tags.

## Validation
- corepack pnpm build

Addresses #1