### PR TITLE
[codex] improve search and filter controls

### DIFF
--- a/src/components/ProjectList.astro
+++ b/src/components/ProjectList.astro
@@ -22,7 +22,7 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
       type="text"
       name="search"
       placeholder="Search..."
-      aria-label="Search"
+      aria-label="Search projects"
     />
   </div>
   <div id="tag-selector-container" class="inputContainer">
@@ -36,7 +36,7 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
       <path d="M7 12h10"></path>
       <path d="M10 19h4"></path>
     </svg>
-    <select id="tag-selector" aria-labelledby="tag-selector-container">
+    <select id="tag-selector" aria-label="Filter projects by tag">
       <option value="">Filter by tags</option>
       {allTags.map(tag => (
         <option value={tag.toLowerCase()}>{tag}</option>

--- a/src/components/ProjectList.astro
+++ b/src/components/ProjectList.astro
@@ -2,8 +2,21 @@
 import ProjectCard from './ProjectCard.astro';
 import { projectList } from '../data/projects.js';
 
-// Get all unique tags for filtering
-const allTags = [...new Set(projectList.flatMap(project => project.tags || []))].sort();
+// Get all unique tags for filtering, ignoring casing so duplicate values share one option
+const tagOptions = projectList
+  .flatMap(project => project.tags || [])
+  .reduce((tags, tag) => {
+    const normalizedTag = tag.toLowerCase();
+
+    if (!tags.has(normalizedTag)) {
+      tags.set(normalizedTag, tag);
+    }
+
+    return tags;
+  }, new Map());
+const allTags = [...tagOptions.values()].sort((firstTag, secondTag) =>
+  firstTag.localeCompare(secondTag, undefined, { sensitivity: 'base' })
+);
 ---
 
 <div id="container">

--- a/src/components/ProjectList.astro
+++ b/src/components/ProjectList.astro
@@ -8,6 +8,15 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
 
 <div id="container">
   <div class="inputContainer">
+    <svg
+      class="inputIcon"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <circle cx="11" cy="11" r="7"></circle>
+      <path d="m16 16 4 4"></path>
+    </svg>
     <input
       id="search"
       type="text"
@@ -17,6 +26,16 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
     />
   </div>
   <div id="tag-selector-container" class="inputContainer">
+    <svg
+      class="inputIcon"
+      aria-hidden="true"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path d="M4 5h16"></path>
+      <path d="M7 12h10"></path>
+      <path d="M10 19h4"></path>
+    </svg>
     <select id="tag-selector" aria-labelledby="tag-selector-container">
       <option value="">Filter by tags</option>
       {allTags.map(tag => (
@@ -131,11 +150,29 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
   .inputContainer {
     flex: 1;
     min-width: 250px;
+    position: relative;
+  }
+
+  .inputIcon {
+    width: 1.125rem;
+    height: 1.125rem;
+    position: absolute;
+    left: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: rgba(255, 255, 255, 0.68);
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    pointer-events: none;
+    z-index: 1;
   }
 
   #search {
     width: 100%;
-    padding: 1rem 1.25rem;
+    padding: 1rem 1.25rem 1rem 3rem;
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 10px;
     background: rgba(255, 255, 255, 0.1);
@@ -157,7 +194,7 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
 
   #tag-selector {
     width: 100%;
-    padding: 1rem 1.25rem;
+    padding: 1rem 1.25rem 1rem 3rem;
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 10px;
     background: rgba(255, 255, 255, 0.1);
@@ -198,8 +235,12 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
       min-width: unset;
     }
     
+    .inputIcon {
+      left: 0.875rem;
+    }
+
     #search, #tag-selector {
-      padding: 0.875rem 1rem;
+      padding: 0.875rem 1rem 0.875rem 2.75rem;
       font-size: 0.95rem;
     }
     


### PR DESCRIPTION
## Summary
- Add decorative search and filter SVG icons to the project list controls.
- Add left padding and responsive icon positioning so control text does not overlap the icons.
- Hide the decorative icons from assistive technology.
- Clarify the control labels as `Search projects` and `Filter projects by tag`.
- Dedupe filter dropdown tags case-insensitively so repeated values like `GitHub`/`Github` and `TypeScript`/`Typescript` only render once.

Addresses #454.
Contributes to #347.

## Validation
- `pnpm build`
- Confirmed rendered `dist/index.html` has the updated input/select `aria-label` values
- Confirmed the old `aria-labelledby="tag-selector-container"` reference is gone
- Node check against built `dist/index.html` confirmed 305 filter options and no duplicate option values
- Source data check showed 39 case-only duplicate tag options removed
- `git diff --check`
