### PR TITLE
[codex] fix Servo project link

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1315,7 +1315,7 @@ export const projectList = [
   {
     name: "Servo",
     imageSrc: "https://avatars.githubusercontent.com/u/2566135?s=200&v=4",
-    projectLink: "https://github.com/digital-asset/daml/contribute",
+    projectLink: "https://github.com/servo/servo/contribute",
     description:
       "A browser engine designed for applications including embedded use.",
     tags: ["Rust", "Browser", "Servo"],


### PR DESCRIPTION
## Summary
- Corrects the Servo project card so its contribution link points to `servo/servo` instead of `digital-asset/daml`.
- Keeps the existing Servo image, description, and tags unchanged.
- Contributes to #1.

## Root cause
The project metadata mixed Servo-facing card details with a copied Daml contribution URL, so users clicking Servo were sent to the wrong repository.

## Validation
- `pnpm build`
- `git diff --check`
- Verified `servo/servo` is public and active, `https://github.com/servo/servo/contribute` returns HTTP 200, and the Servo avatar URL returns `image/png`.
