### PR TITLE
[codex] add Appwrite, Supabase, Hoppscotch, and Excalidraw

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -70,6 +70,15 @@ export const projectList = [
     loadIssues: true,
     tags: ["TypeScript", "Backend", "Serverless", "Database", "Auth"],
   },
+  {
+    name: "Supabase",
+    imageSrc: "https://avatars.githubusercontent.com/u/54469796?v=4",
+    projectLink: "https://github.com/supabase/supabase/contribute",
+    description:
+      "A Postgres development platform for building web, mobile, and AI applications with auth, realtime, and storage.",
+    loadIssues: true,
+    tags: ["TypeScript", "Postgres", "Database", "Auth", "Realtime"],
+  },
 
   {
     name: "Hamilton",
@@ -96,6 +105,15 @@ export const projectList = [
       "An open-source API development ecosystem for REST, GraphQL, realtime APIs, desktop, web, and CLI workflows.",
     loadIssues: true,
     tags: ["TypeScript", "Vue", "API", "GraphQL", "Developer Tools"],
+  },
+  {
+    name: "Excalidraw",
+    imageSrc: "https://avatars.githubusercontent.com/u/59452120?v=4",
+    projectLink: "https://github.com/excalidraw/excalidraw/contribute",
+    description:
+      "A virtual whiteboard for sketching hand-drawn-style diagrams and collaborating visually.",
+    loadIssues: true,
+    tags: ["TypeScript", "Canvas", "Collaboration", "Diagrams", "Productivity"],
   },
 
   {

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -61,6 +61,15 @@ export const projectList = [
     description: "Drag & Drop internal tool builder",
     tags: ["UI", "Database", "Editor"],
   },
+  {
+    name: "Appwrite",
+    imageSrc: "https://avatars.githubusercontent.com/u/25003669?v=4",
+    projectLink: "https://github.com/appwrite/appwrite/contribute",
+    description:
+      "A backend platform for building web, mobile, and AI apps with auth, databases, storage, functions, and realtime APIs.",
+    loadIssues: true,
+    tags: ["TypeScript", "Backend", "Serverless", "Database", "Auth"],
+  },
 
   {
     name: "Hamilton",
@@ -78,6 +87,15 @@ export const projectList = [
     projectLink: "https://github.com/altair-graphql/altair",
     description: "A beautiful feature-rich GraphQL Client for all platforms.",
     tags: ["GraphQL", "React", "TypeScript"],
+  },
+  {
+    name: "Hoppscotch",
+    imageSrc: "https://avatars.githubusercontent.com/u/56705483?v=4",
+    projectLink: "https://github.com/hoppscotch/hoppscotch/contribute",
+    description:
+      "An open-source API development ecosystem for REST, GraphQL, realtime APIs, desktop, web, and CLI workflows.",
+    loadIssues: true,
+    tags: ["TypeScript", "Vue", "API", "GraphQL", "Developer Tools"],
   },
 
   {


### PR DESCRIPTION
## Summary
- Adds Appwrite, Supabase, Hoppscotch, and Excalidraw to the project list.
- Includes each project's GitHub avatar, contribution link, concise tags, and live beginner issue loading.
- Contributes to #1.

## Why
These are active, unarchived repositories with open `good first issue` items, giving first-time contributors more current places to start.

## Validation
- `pnpm build`
- `git diff --check`
- Verified each of the four projects appears exactly once in `src/data/projects.js` with the expected `/contribute` URL.
- Verified all four `/contribute` pages return HTTP 200 and all four avatar URLs return image content.
