### PR TITLE
[codex] pin pnpm in GitHub workflows

### DIFF
--- a/.github/workflows/deploy-to-gh-pages.yml
+++ b/.github/workflows/deploy-to-gh-pages.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install, build, and upload your site output
         uses: withastro/action@v2
         with:
-            package-manager: pnpm@latest
+            package-manager: pnpm@10.33.4
 
   deploy:
     needs: build

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10.33.4
 
       - name: Install dependencies
         if: github.event.action != 'closed'


### PR DESCRIPTION
## Summary

Pin the pnpm version used by the PR preview workflow and the GitHub Pages deploy workflow to `10.33.4` instead of `latest`.

## Why

The preview workflow pins Node.js 20 but installs `pnpm@latest`. The current latest pnpm release is 11.x, whose package metadata requires Node.js `>=22.13`. Dependabot PR preview runs #597 and #598 both failed before dependency installation with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` after pnpm 11 was installed on Node 20.

Pinning pnpm to the latest 10.x release keeps the current Node 20 workflow compatible and prevents future `latest` drift from breaking preview or Pages deploy runs unexpectedly.

## Validation

- `npm view pnpm@latest version engines --json` reports pnpm 11.1.2 requires `node >=22.13`
- `npm view pnpm@10.33.4 version engines --json` reports pnpm 10.33.4 requires `node >=18.12`
- `pnpm build`
- `git diff --check`
