### PR TITLE
[codex] fix issue label class binding

### DIFF
--- a/src/components/IssueList.astro
+++ b/src/components/IssueList.astro
@@ -131,7 +131,7 @@ if (repoInfo) {
             </div>
           </div>
           <div class="Issue-Labels">
-            <span class="Issue-Label {issue.priority === 'good first issue' ? 'good-first-issue' : 'help-wanted'}">
+            <span class={`Issue-Label ${issue.priority === 'good first issue' ? 'good-first-issue' : 'help-wanted'}`}>
               {issue.priority === 'good first issue' ? 'Good First Issue' : 'Help Wanted'}
             </span>
           </div>


### PR DESCRIPTION
## Summary

- Fix the dynamic issue label class binding in `IssueList.astro`.
- Let rendered issue cards receive either `good-first-issue` or `help-wanted` so the existing modifier styles apply.

## Why

The previous class attribute included the conditional expression inside a plain string, so Astro rendered the expression text literally in the built HTML instead of evaluating it.

## Validation

- `pnpm build`
- Confirmed `dist/index.html` renders `Issue-Label good-first-issue` and no longer contains `{issue.priority ...}`
- `git diff --check`
