### PR TITLE
[codex] remove rendered key attributes from tags

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -29,7 +29,7 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     <div class="Card-Body">
       <div class="Card-Tag">
         {tags.map((tag) => (
-          <div key={tag}>
+          <div>
             <p>{tag}</p>
           </div>
         ))}
@@ -219,4 +219,3 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     }
   }
 </style>
-


### PR DESCRIPTION
## Summary

- Remove the React-only `key` attribute from project tag wrappers in `ProjectCard.astro`.

## Why

Astro does not treat `key={tag}` as a framework diffing hint in this server-rendered markup, so it was emitted into the final HTML as `key="..."` on every project tag wrapper. Removing it keeps the generated markup cleaner and avoids invalid/noisy attributes.

## Validation

- `pnpm build`
- Confirmed built `dist/index.html` no longer contains `<div key="...">` project tag wrappers
- `git diff --check`

Contributes to #347.
