### PR TITLE
[codex] label navbar social links

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -2,7 +2,7 @@
 // Navbar component for social links
 ---
 
-<div class="topnav">
+<nav class="topnav" aria-label="First Contributions links">
   <a href="https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w" target="_blank" rel="noopener noreferrer" aria-label="Open First Contributions Slack">
     <img src="/slack.svg" class="logo" alt="" aria-hidden="true" />
     <span>Slack</span>
@@ -19,7 +19,7 @@
     <img src="/github.svg" class="logo" alt="" aria-hidden="true" />
     <span>GitHub</span>
   </a>
-</div>
+</nav>
 
 <style>
   .topnav {

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,20 +3,20 @@
 ---
 
 <div class="topnav">
-  <a href="https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w" target="_blank" rel="noopener noreferrer">
-    <img src="/slack.svg" class="logo" alt="slack logo" />
+  <a href="https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w" target="_blank" rel="noopener noreferrer" aria-label="Open First Contributions Slack">
+    <img src="/slack.svg" class="logo" alt="" aria-hidden="true" />
     <span>Slack</span>
   </a>
-  <a href="https://www.youtube.com/channel/UCMXNFxCvyH5LhUwEcmY8qGQ" target="_blank" rel="noopener noreferrer">
-    <img src="/youtube.svg" class="logo" alt="youtube logo" />
-    <span>Youtube</span>    
+  <a href="https://www.youtube.com/channel/UCMXNFxCvyH5LhUwEcmY8qGQ" target="_blank" rel="noopener noreferrer" aria-label="Open First Contributions on YouTube">
+    <img src="/youtube.svg" class="logo" alt="" aria-hidden="true" />
+    <span>YouTube</span>
   </a>
-  <a href="https://twitter.com/1stContribution" target="_blank" rel="noopener noreferrer">
-    <img src="/twitter.svg" class="logo" alt="twitter logo" />
+  <a href="https://twitter.com/1stContribution" target="_blank" rel="noopener noreferrer" aria-label="Open First Contributions on Twitter">
+    <img src="/twitter.svg" class="logo" alt="" aria-hidden="true" />
     <span>Twitter</span>
   </a>
-  <a href="https://github.com/firstcontributions/first-contributions" target="_blank" rel="noopener noreferrer">
-    <img src="/github.svg" class="logo" alt="github logo" />
+  <a href="https://github.com/firstcontributions/first-contributions" target="_blank" rel="noopener noreferrer" aria-label="Open First Contributions on GitHub">
+    <img src="/github.svg" class="logo" alt="" aria-hidden="true" />
     <span>GitHub</span>
   </a>
 </div>


### PR DESCRIPTION
## Summary

- Add explicit accessible labels to the navbar social links.
- Treat the visible social icons as decorative so the link name stays stable when text is hidden on small screens.
- Use a labeled `<nav>` landmark for the top link group.
- Fix the visible YouTube brand casing.

## Why

The navbar hides its text labels at mobile widths. Explicit `aria-label` values keep each social link named consistently, while empty decorative image alts avoid duplicate names like `youtube logo YouTube` when the text is visible. A semantic nav landmark also gives assistive technology a named region for the top link group.

## Validation

- `pnpm build`
- Confirmed built `dist/index.html` renders the labeled `nav`, navbar link `aria-label` attributes, decorative icon `alt="" aria-hidden="true"`, and `YouTube` casing
- `git diff --check`

Related to #347.
