### PR TITLE
[codex] remove stale sitemap lastmod dates

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,13 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://firstcontributions.github.io/</loc>
-    <lastmod>2025-01-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://firstcontributions.github.io/contribute-to-opensource</loc>
-    <lastmod>2025-01-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary

- Remove hardcoded `lastmod` values from `public/sitemap.xml`.

## Why

The sitemap is a static file, and both pages currently report `2025-01-27` as their last modification date even though the site and metadata have changed since then. Omitting `lastmod` is more accurate than shipping stale modification dates until the sitemap can be generated from real page metadata.

## Validation

- `xmllint --noout public/sitemap.xml`
- `pnpm build`
- Confirmed `dist/sitemap.xml` matches `public/sitemap.xml`
- Confirmed neither sitemap contains `<lastmod>` and both still include the two page URLs
- `git diff --check`

Contributes to #348.
