### PR TITLE
[codex] fix Public Lab project link

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -443,7 +443,7 @@ export const projectList = [
   {
     name: "Public Lab",
     imageSrc: "https://code.publiclab.org/images/Boots-ground-02.png",
-    projectLink: "https://publiclab.github.io/community-toolbox/#r=all",
+    projectLink: "https://github.com/publiclab/plots2/contribute",
     description:
       "PublicLab.org - a collaborative knowledge-exchange platform in Rails; we welcome first-time contributors! 🎈",
     tags: [


### PR DESCRIPTION
## Summary
- update the Public Lab card to link to the active `publiclab/plots2` GitHub contribute page
- replace the stale `publiclab.github.io/community-toolbox` URL, which redirects to a host that currently fails DNS

Refs #347

## Validation
- `curl -I -L --max-time 15 https://github.com/publiclab/plots2/contribute` returns HTTP 200
- `pnpm build`
- confirmed the generated `dist/index.html` contains `https://github.com/publiclab/plots2/contribute`
- `git diff --check`
