### PR TITLE
[codex] respect reduced motion preference

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -128,3 +128,16 @@ const {
 		box-sizing: border-box;
 	}
 </style>
+
+<style is:global>
+	@media (prefers-reduced-motion: reduce) {
+		*,
+		*::before,
+		*::after {
+			animation-duration: 0.01ms !important;
+			animation-iteration-count: 1 !important;
+			scroll-behavior: auto !important;
+			transition-duration: 0.01ms !important;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- add a global `prefers-reduced-motion: reduce` rule
- shorten animations and transitions for users who request reduced motion
- keep the existing visual behavior unchanged for everyone else

Refs #347
Refs #501

## Validation
- `pnpm build`
- confirmed the compiled CSS contains the `prefers-reduced-motion` rule
- `git diff --check`
