### PR TITLE
[codex] harden issue preview fetching

### DIFF
--- a/src/components/IssueList.astro
+++ b/src/components/IssueList.astro
@@ -59,11 +59,12 @@ async function fetchIssues(owner: string, repo: string) {
       }
       
       const issues = await response.json();
+      const issuesOnly = issues.filter((issue: any) => !issue.pull_request);
       
-      allIssues = [...allIssues, ...issues];
+      allIssues = [...allIssues, ...issuesOnly];
       
       // If we found issues, break to avoid duplicates
-      if (issues.length > 0) {
+      if (issuesOnly.length > 0) {
         break;
       }
     }

--- a/src/components/IssueList.astro
+++ b/src/components/IssueList.astro
@@ -8,14 +8,24 @@ const { projectLink, projectName } = Astro.props;
 
 // Extract owner/repo from GitHub URL
 function extractRepoInfo(url: string) {
-  const match = url.match(/github\.com\/([^\/]+)\/([^\/]+)/);
-  if (match) {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.hostname !== 'github.com') {
+      return null;
+    }
+
+    const [owner, repo] = parsedUrl.pathname.split('/').filter(Boolean);
+    if (!owner || !repo) {
+      return null;
+    }
+
     return {
-      owner: match[1],
-      repo: match[2].replace(/\/$/, '') // Remove trailing slash
+      owner,
+      repo: repo.replace(/\.git$/, '')
     };
+  } catch {
+    return null;
   }
-  return null;
 }
 
 // Fetch issues from GitHub API on the server
@@ -36,6 +46,7 @@ async function fetchIssues(owner: string, repo: string) {
     const labelCombinations = [
       'good first issue,help wanted',  // Both labels
       'good first issue',              // Just good first issue
+      'good-first-issue',              // Hyphenated good first issue
       'help wanted'                    // Just help wanted
     ];
     


### PR DESCRIPTION
## Summary
- filter GitHub API results with `pull_request` out of homepage issue previews
- parse GitHub project URLs with `URL` and pathname segments instead of a broad regex
- support `/contribute`, fragment, and `.git` repo URLs while ignoring org/search/non-GitHub links
- include the hyphenated `good-first-issue` label variant in preview fetching

Refs #347
Refs #1

## Validation
- `pnpm build`
- parser spot-checks for `/contribute`, `#fragment`, `.git`, GitHub search/org URLs, and non-GitHub URLs
- `git diff --check`
