### PR TITLE
[codex] align browserconfig tile color

### DIFF
--- a/public/browserconfig.xml
+++ b/public/browserconfig.xml
@@ -3,7 +3,7 @@
     <msapplication>
         <tile>
             <square150x150logo src="/mstile-150x150.png"/>
-            <TileColor>#da532c</TileColor>
+            <TileColor>#667eea</TileColor>
         </tile>
     </msapplication>
 </browserconfig>


### PR DESCRIPTION
## Summary
- align `public/browserconfig.xml` with the existing app theme color
- make the legacy Microsoft tile color match `theme-color`, `msapplication-TileColor`, mask-icon color, and manifest `theme_color`

Refs #347

## Validation
- `xmllint --noout public/browserconfig.xml`
- `pnpm build`
- confirmed `dist/browserconfig.xml` contains `#667eea`
- `git diff --check`
