### PR TITLE
[codex] mark app package private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firstcontributions webapp",
+  "private": true,
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "preview": "astro preview",
     "astro": "astro"
   },
+  "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+  },
   "dependencies": {
     "astro": "^5.15.9"
   }


### PR DESCRIPTION
## Summary
- mark the Astro app package as private
- add a Node engine guard matching Astro 5's supported runtime range
- prevent accidental npm publishing/packing assumptions and give contributors clearer local runtime metadata

Refs #347

## Validation
- `pnpm build`
- `npm pkg get private --workspaces=false`
- `node -e 'const pkg=require("./package.json"); if (pkg.private !== true) process.exit(1); if (pkg.engines.node !== "18.20.8 || ^20.3.0 || >=22.0.0") process.exit(2); console.log(pkg.private, pkg.engines.node)'`
- `git diff --check`
