### PR TITLE
[codex] remove stale React tsconfig options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,5 @@
   ],
   "exclude": [
     "dist"
-  ],
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "react"
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- remove the old React JSX compiler options from `tsconfig.json`
- keep the TypeScript config aligned with the current Astro-only source tree

Refs #347

## Validation
- `pnpm build`
- `node -e 'JSON.parse(require("fs").readFileSync("tsconfig.json", "utf8")); console.log("valid json")'`
- `rg "react-jsx|jsxImportSource" tsconfig.json src package.json` returns no matches
- `git diff --check`
