### PR TITLE
[codex] add search and filter icons

### DIFF
--- a/src/components/ProjectList.astro
+++ b/src/components/ProjectList.astro
@@ -8,6 +8,19 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
 
 <div id="container">
   <div class="inputContainer">
+    <svg
+      class="inputIcon"
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="11" cy="11" r="8"></circle>
+      <path d="m21 21-4.35-4.35"></path>
+    </svg>
     <input
       id="search"
       type="text"
@@ -17,7 +30,21 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
     />
   </div>
   <div id="tag-selector-container" class="inputContainer">
-    <select id="tag-selector" aria-labelledby="tag-selector-container">
+    <svg
+      class="inputIcon"
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M3 5h18"></path>
+      <path d="M7 12h10"></path>
+      <path d="M10 19h4"></path>
+    </svg>
+    <select id="tag-selector" aria-label="Filter projects by tag">
       <option value="">Filter by tags</option>
       {allTags.map(tag => (
         <option value={tag.toLowerCase()}>{tag}</option>
@@ -131,11 +158,26 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
   .inputContainer {
     flex: 1;
     min-width: 250px;
+    position: relative;
   }
 
-  #search {
+  .inputIcon {
+    color: rgba(255, 255, 255, 0.62);
+    height: 1.2rem;
+    left: 1rem;
+    pointer-events: none;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 1.2rem;
+    z-index: 1;
+  }
+
+  #search,
+  #tag-selector {
     width: 100%;
-    padding: 1rem 1.25rem;
+    box-sizing: border-box;
+    padding: 1rem 1.25rem 1rem 3rem;
     border: 1px solid rgba(255, 255, 255, 0.2);
     border-radius: 10px;
     background: rgba(255, 255, 255, 0.1);
@@ -153,18 +195,6 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
     outline: none;
     border-color: #667eea;
     box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.2);
-  }
-
-  #tag-selector {
-    width: 100%;
-    padding: 1rem 1.25rem;
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 10px;
-    background: rgba(255, 255, 255, 0.1);
-    color: white;
-    font-size: 1rem;
-    backdrop-filter: blur(10px);
-    transition: all 0.3s ease;
   }
 
   #tag-selector:focus {

--- a/src/components/ProjectList.astro
+++ b/src/components/ProjectList.astro
@@ -229,7 +229,7 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
     }
     
     #search, #tag-selector {
-      padding: 0.875rem 1rem;
+      padding: 0.875rem 1rem 0.875rem 2.75rem;
       font-size: 0.95rem;
     }
     


### PR DESCRIPTION
## Summary
- add decorative search and filter icons to the project-list controls
- keep the icons hidden from assistive tech with `aria-hidden="true"`
- replace the filter select's broken `aria-labelledby` reference with a direct accessible label

Closes #454

## Validation
- `git diff --check`
- `pnpm build`
- inspected built `dist/index.html` for two decorative icons, the search label, and `aria-label="Filter projects by tag"`