### PR TITLE
[codex] improve project logo images

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -18,7 +18,7 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     <div class="Card-Header">
       <img
         class="Project-Logo"
-        alt="the framework or language that the project is build upon"
+        alt={`${name} logo`}
         src={logoLink}
         onerror="this.src='/default.png'"
         width="60"

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -23,6 +23,8 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
         onerror="this.src='/default.png'"
         width="60"
         height="60"
+        loading="lazy"
+        decoding="async"
       />
       <p class="Card-Title">{name}</p>
     </div>
@@ -219,4 +221,3 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     }
   }
 </style>
-


### PR DESCRIPTION
## Summary
- add native `loading="lazy"` to project logo images
- add `decoding="async"` so logo decoding does not block rendering work
- replace the generic project-logo alt text with project-specific alt text from the card name
- keep the existing fixed `width`/`height` attributes intact

Addresses #470, #347, and #348.

## Validation
- `git diff --check`
- `pnpm build`
- inspected built `dist/index.html`: all 152 `.Project-Logo` images include `loading="lazy"`, `decoding="async"`, and the existing `width="60" height="60"` attributes
- inspected built `dist/index.html`: generic logo alt text count is 0, with project-specific examples such as `activist.org logo`, `CircuitVerse logo`, and `Open Source Diversity logo`