### PR TITLE
[codex] remove expired Slack navbar link

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,10 +3,6 @@
 ---
 
 <div class="topnav">
-  <a href="https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w" target="_blank" rel="noopener noreferrer">
-    <img src="/slack.svg" class="logo" alt="slack logo" />
-    <span>Slack</span>
-  </a>
   <a href="https://www.youtube.com/channel/UCMXNFxCvyH5LhUwEcmY8qGQ" target="_blank" rel="noopener noreferrer">
     <img src="/youtube.svg" class="logo" alt="youtube logo" />
     <span>Youtube</span>    


### PR DESCRIPTION
## Summary
- removes the expired Slack invite from the navbar
- keeps the remaining YouTube, Twitter, and GitHub navbar links unchanged

Closes #570.

## Validation
- `curl -I -L --max-time 30 https://join.slack.com/t/firstcontributors/shared_invite/zt-1n4y7xnk0-DnLVTaN6U9xLU79H5Hi62w` returns HTTP 403 after redirect
- `git diff --check`
- `pnpm build`
- inspected `dist/index.html`: no Slack invite remains, and the other navbar links still render
