### PR TITLE
[codex] add Storybook to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1458,4 +1458,12 @@ export const projectList = [
     description: "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
     tags: ["Python", "Automation", "Configuration Management"],
   },
+  {
+    name: "Storybook",
+    imageSrc: "https://avatars.githubusercontent.com/u/22632046?s=200&v=4",
+    projectLink: "https://github.com/storybookjs/storybook",
+    description: "Storybook is a workshop for building, documenting, and testing UI components in isolation.",
+    loadIssues: true,
+    tags: ["JavaScript", "TypeScript", "UI", "Components", "Testing"],
+  },
 ];


### PR DESCRIPTION
## Summary
- adds Storybook to the project suggestions list
- enables beginner-friendly issue previews for the Storybook card

Addresses #1.

## Validation
- verified `storybookjs/storybook` is public and not archived
- verified current open beginner-friendly issues: #12497, #8596, #23862 all have `good first issue` and `help wanted` labels
- `git diff --check`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- inspected `dist/index.html`: Storybook card renders, 153 project cards total, and Storybook issue previews render
