### PR TITLE
[codex] add Docusaurus to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -976,6 +976,14 @@ export const projectList = [
     ],
   },
   {
+    name: "Docusaurus",
+    imageSrc: "https://avatars.githubusercontent.com/u/69631?s=200&v=4",
+    projectLink: "https://github.com/facebook/docusaurus",
+    description: "Easy to maintain open source documentation websites.",
+    loadIssues: true,
+    tags: ["JavaScript", "React", "Documentation", "Website"],
+  },
+  {
     name: "ClickHouse",
     imageSrc:
       "https://github.com/ClickHouse/clickhouse-presentations/raw/master/images/logo-400x240.png",


### PR DESCRIPTION
## Summary
- adds Docusaurus to the project suggestions list
- enables beginner-friendly issue previews for the Docusaurus card

Addresses #1.

## Validation
- verified `facebook/docusaurus` is public and not archived
- verified current open beginner-friendly issue #5691 has `good first issue` and `status: accepting pr` labels
- verified the Docusaurus avatar URL returns `200 image/png`
- `git diff --check`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- inspected `dist/index.html`: Docusaurus card renders, 153 project cards total, and Docusaurus issue #5691 renders
