### PR TITLE
[codex] add Grafana to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1403,6 +1403,15 @@ export const projectList = [
     ],
   },
   {
+    name: "Grafana",
+    imageSrc: "https://avatars.githubusercontent.com/u/7195757?s=200&v=4",
+    projectLink: "https://github.com/grafana/grafana",
+    description:
+      "Grafana is an open and composable observability and data visualization platform.",
+    loadIssues: true,
+    tags: ["Go", "TypeScript", "Observability", "Monitoring", "Dashboard"],
+  },
+  {
     name: "MeiliSearch",
     imageSrc: "https://avatars.githubusercontent.com/u/43250847?s=200&v=4",
     projectLink: "https://github.com/meilisearch/meilisearch",


### PR DESCRIPTION
## Summary
- adds Grafana to the project suggestions list
- enables beginner-friendly issue previews for the Grafana card

Addresses #1.

## Validation
- verified `grafana/grafana` is public and not archived
- verified current rendered issue previews #115711, #102190, and #74382 are open with `good first issue` and `help wanted` labels
- verified the Grafana avatar URL returns `200 image/jpeg`
- `git diff --check`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- inspected `dist/index.html`: Grafana card renders, 153 project cards total, and Grafana issue previews render
