### PR TITLE
[codex] fix Twitter meta handle

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -61,13 +61,13 @@ const {
 		<meta property="og:site_name" content="First Contributions" />
 		
 		<!-- Twitter -->
-		<meta property="twitter:card" content="summary_large_image" />
-		<meta property="twitter:url" content={url} />
-		<meta property="twitter:title" content={title} />
-		<meta property="twitter:description" content={description} />
-		<meta property="twitter:image" content={image} />
-		<meta property="twitter:creator" content="@1stContribution" />
-		<meta property="twitter:site" content="@1stContribution" />
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:url" content={url} />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={image} />
+		<meta name="twitter:creator" content="@1stContribution" />
+		<meta name="twitter:site" content="@1stContribution" />
 		
 		<!-- Structured Data / Schema.org -->
 		<script type="application/ld+json">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -66,8 +66,8 @@ const {
 		<meta property="twitter:title" content={title} />
 		<meta property="twitter:description" content={description} />
 		<meta property="twitter:image" content={image} />
-		<meta property="twitter:creator" content="@firstcontrib" />
-		<meta property="twitter:site" content="@firstcontrib" />
+		<meta property="twitter:creator" content="@1stContribution" />
+		<meta property="twitter:site" content="@1stContribution" />
 		
 		<!-- Structured Data / Schema.org -->
 		<script type="application/ld+json">


### PR DESCRIPTION
## Summary
- align the default layout Twitter card metadata with the project Twitter handle used in the navbar and share link
- replace the stale @firstcontrib metadata value with @1stContribution
- use name attributes for twitter:* card metadata tags

## Why
The homepage social metadata should point at the same account the site links to and should emit Twitter card tags in the expected meta name form. This keeps Twitter/X card attribution consistent with the project UI and helps the SEO/social-preview work tracked in #348.

Refs #348.

## Validation
- pnpm build
- git diff --check
- verified built dist/index.html emits name="twitter:*" card metadata, twitter:creator, and twitter:site as @1stContribution before restoring generated output