### PR TITLE
[codex] fix article metadata asset links

### DIFF
--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -84,7 +84,7 @@
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "How to Contribute to Open Source: A Complete Guide for Beginners",
-      "description": "Learn how to start contributing to open source projects with this comprehensive guide. Perfect for beginners, including step-by-step instructions, best practices, and expert tips.Learn how to contribute to open source with this beginner-friendly guide. Discover the benefits, steps, and best practices for making your first contribution.",
+      "description": "Learn how to contribute to open source with this beginner-friendly guide. Discover the benefits, steps, and best practices for making your first contribution.",
       "image": "https://firstcontributions.github.io/og-image.svg",
       "author": {
         "@type": "Person",

--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -43,13 +43,13 @@
   />
 
   <!-- Twitter -->
-  <meta property="twitter:card" content="summary_large_image" />
+  <meta name="twitter:card" content="summary_large_image" />
   <meta
-    property="twitter:url"
+    name="twitter:url"
     content="https://firstcontributions.github.io/contribute-to-opensource"
   />
   <meta
-    property="twitter:title"
+    name="twitter:title"
     content="How to Contribute to Open Source: A Complete Guide for Beginners"
   />
   <meta
@@ -57,7 +57,7 @@
     content="Learn how to contribute to open source with this beginner-friendly guide. Discover the benefits, steps, and best practices for making your first contribution."
   />
   <meta
-    property="twitter:image"
+    name="twitter:image"
     content="https://firstcontributions.github.io/og-image.svg"
   />
 

--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -39,7 +39,7 @@
   />
   <meta
     property="og:image"
-    content="https://firstcontributions.github.io/assets/preview-image.jpg"
+    content="https://firstcontributions.github.io/og-image.svg"
   />
 
   <!-- Twitter -->
@@ -58,11 +58,11 @@
   />
   <meta
     property="twitter:image"
-    content="https://firstcontributions.github.io/assets/preview-image.jpg"
+    content="https://firstcontributions.github.io/og-image.svg"
   />
 
   <!-- Canonical URL -->
-  <meta
+  <link
     rel="canonical"
     href="https://firstcontributions.github.io/contribute-to-opensource"
   />
@@ -70,8 +70,8 @@
   <!-- Favicon -->
   <link
     rel="icon"
-    type="image/png"
-    href="https://firstcontributions.github.io/assets/first-contributions-logo.svg"
+    type="image/svg+xml"
+    href="https://firstcontributions.github.io/favicon.svg"
   />
   <link
     rel="stylesheet"
@@ -85,7 +85,7 @@
       "@type": "Article",
       "headline": "How to Contribute to Open Source: A Complete Guide for Beginners",
       "description": "Learn how to start contributing to open source projects with this comprehensive guide. Perfect for beginners, including step-by-step instructions, best practices, and expert tips.Learn how to contribute to open source with this beginner-friendly guide. Discover the benefits, steps, and best practices for making your first contribution.",
-      "image": "https://firstcontributions.github.io/assets/preview-image.jpg",
+      "image": "https://firstcontributions.github.io/og-image.svg",
       "author": {
         "@type": "Person",
         "name": "sudo !!"
@@ -95,7 +95,7 @@
         "name": "First contributions",
         "logo": {
           "@type": "ImageObject",
-          "url": "https://firstcontributions.github.io/assets/first-contributions-logo.svg"
+          "url": "https://firstcontributions.github.io/favicon.svg"
         }
       },
       "datePublished": "2025-02-01",

--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -1,7 +1,7 @@
 ---
 ---
 
-<html>
+<html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
Summary:
- Replace missing contribute-to-opensource social image URLs with the existing og-image.svg asset.
- Replace the missing article publisher/favicon logo URL with the existing favicon.svg asset.
- Correct the canonical URL element from meta rel=canonical to link rel=canonical.
- Use name attributes for the article twitter:* card metadata tags.

Validation:
- GITHUB_TOKEN=... pnpm build
- git diff --check
- Confirmed built dist/contribute-to-opensource/index.html references og-image.svg and favicon.svg, emits name="twitter:*" tags, and no longer references assets/preview-image.jpg or assets/first-contributions-logo.svg.