### PR TITLE
[codex] align browserconfig tile color

### DIFF
--- a/public/browserconfig.xml
+++ b/public/browserconfig.xml
@@ -3,7 +3,7 @@
     <msapplication>
         <tile>
             <square150x150logo src="/mstile-150x150.png"/>
-            <TileColor>#da532c</TileColor>
+            <TileColor>#667eea</TileColor>
         </tile>
     </msapplication>
 </browserconfig>


### PR DESCRIPTION
Summary:
- Align public/browserconfig.xml TileColor with the existing site theme color.
- Match the color already used by manifest.json theme_color, the msapplication-TileColor meta tag, and the Safari mask icon.

Validation:
- pnpm build
- git diff --check main...HEAD
- Confirmed built dist/browserconfig.xml uses #667eea before restoring generated output.

Refs #347.