### PR TITLE
[codex] remove stale sitemap lastmod dates

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,13 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://firstcontributions.github.io/</loc>
-    <lastmod>2025-01-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://firstcontributions.github.io/contribute-to-opensource</loc>
-    <lastmod>2025-01-27</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
Summary:
- Remove hard-coded 2025 lastmod values from the static sitemap.
- Keep the sitemap URLs, changefreq, and priority hints intact.

Why:
The static sitemap is not generated from page modification times, so the fixed 2025-01-27 lastmod values can become stale and misleading as the site changes.

Validation:
- xmllint --noout public/sitemap.xml
- pnpm build
- git diff --check main...HEAD
- Confirmed built dist/sitemap.xml contains no lastmod entries after the build, then restored generated output.

Refs #348.