### PR TITLE
[codex] remove stale React tsconfig options

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,5 @@
   ],
   "exclude": [
     "dist"
-  ],
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "react"
-  }
+  ]
 }


### PR DESCRIPTION
Summary:
- Remove stale React JSX compiler options from tsconfig.json.
- Keep the Astro strict tsconfig extension, include, and dist exclusion intact.

Why:
This app no longer has React source files or a React dependency, so jsx/react-specific compiler settings are stale project metadata.

Validation:
- node -e JSON.parse(...) on tsconfig.json
- rg confirmed no jsx/react-jsx compiler settings remain in project config or source
- pnpm build
- git diff --check main...HEAD
- Restored generated .astro/dist output after build.

Refs #347.