### PR TITLE
[codex] add package metadata guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "firstcontributions webapp",
+  "private": true,
   "type": "module",
   "version": "0.0.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "preview": "astro preview",
     "astro": "astro"
   },
+  "engines": {
+    "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+  },
   "dependencies": {
     "astro": "^5.15.9"
   }


### PR DESCRIPTION
Summary:
- Mark the site package as private to prevent accidental npm publishing.
- Add a Node engine range matching Astro 5.15.9's own supported Node range.

Validation:
- Compared package.json engines.node against node_modules/astro/package.json engines.node
- pnpm build
- git diff --check main...HEAD
- Restored generated .astro/dist output after build.

Refs #347.