### PR TITLE
[codex] remove rendered key attributes from tags

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -29,7 +29,7 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     <div class="Card-Body">
       <div class="Card-Tag">
         {tags.map((tag) => (
-          <div key={tag}>
+          <div>
             <p>{tag}</p>
           </div>
         ))}
@@ -219,4 +219,3 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     }
   }
 </style>
-


### PR DESCRIPTION
Summary:
- Remove React-style key attributes from rendered project tag wrappers.
- Keep the existing tag markup and styling otherwise unchanged.

Validation:
- Source scan found no remaining key attributes in Astro components/pages/layouts.
- pnpm build
- git diff --check main...HEAD
- Built HTML scan found no rendered key attributes in dist/index.html or the guide page, then generated output was restored.

Refs #347.