### PR TITLE
[codex] use relative guide link

### DIFF
--- a/src/components/App.astro
+++ b/src/components/App.astro
@@ -10,7 +10,7 @@ import SocialShare from './SocialShare.astro';
   <div class="App-header">
     <h1>
       Make your first <br/> 
-      <a href="https://firstcontributions.github.io/contribute-to-opensource"> 
+      <a href="/contribute-to-opensource">
         open source <span>contribution</span> 
       </a> 
       <br/> in 5 minutes


### PR DESCRIPTION
## Summary
- change the homepage hero guide link from the production URL to the app-relative guide path
- keep local builds and PR previews on the same origin when users click the guide link

Refs #501

## Validation
- GITHUB_TOKEN=$(gh auth token) pnpm build
- checked generated dist/index.html has one href="/contribute-to-opensource" hero link and no production-domain guide href
- checked generated dist/contribute-to-opensource/index.html exists and contains the guide page
- git diff --check main...HEAD