### PR TITLE
[codex] open get started guide safely

### DIFF
--- a/src/components/LinkButton.astro
+++ b/src/components/LinkButton.astro
@@ -3,7 +3,12 @@
 ---
 
 <div class="LinkButton-Wrapper">
-  <a class="LinkButton" href="https://github.com/firstcontributions/first-contributions/blob/main/README.md">
+  <a
+    class="LinkButton"
+    href="https://github.com/firstcontributions/first-contributions/blob/main/README.md"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
     <span>Get started</span>
   </a>
 </div>


### PR DESCRIPTION
## Summary
- make the external Get started CTA open in a new tab like the other off-site links
- add rel="noopener noreferrer" to the GitHub guide link

Refs #501
Refs #347

## Validation
- GITHUB_TOKEN=$(gh auth token) pnpm build
- confirmed generated dist/index.html renders the LinkButton anchor with target="_blank" and rel="noopener noreferrer"
- git diff --check main...HEAD