### PR TITLE
[codex] fix Codename One project logo

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1206,7 +1206,7 @@ export const projectList = [
   {
     name: "Codename One",
     imageSrc:
-      "https://www.codenameone.com/wp-content/uploads/2020/08/footer-logo.png",
+      "https://avatars.githubusercontent.com/u/2353641?s=200&v=4",
     projectLink: "https://github.com/codenameone/CodenameOne",
     description:
       "Cross-platform mobile app development framework for Java & Kotlin developers",


### PR DESCRIPTION
## Summary
- replace the broken Codename One project logo URL with the GitHub owner avatar
- keep the project link and description unchanged

## Validation
- old Codename One logo URL returns 404 text/html
- new GitHub avatar URL returns 200 image/png
- codenameone/CodenameOne is public, unarchived, and uses master as its default branch
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contains the Codename One card with the new logo URL and no old footer-logo URL
- git diff --check origin/main...HEAD

Refs #347 and #470.
