### PR TITLE
[codex] trim AnitaB project name

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -499,7 +499,7 @@ export const projectList = [
     tags: ["CSS", "tips", "guide", "simple", "useful"],
   },
   {
-    name: "AnitaB.org ",
+    name: "AnitaB.org",
     imageSrc:
       "https://user-images.githubusercontent.com/60894542/94313579-9780c080-ff9c-11ea-8853-daa2a1c0fff5.png",
     projectLink: "https://github.com/anitab-org",


### PR DESCRIPTION
## Summary
- remove the trailing space from the AnitaB.org project card name
- keep the existing project link, image, description, and tags unchanged

## Validation
- AnitaB.org project link returns 200
- AnitaB.org image URL returns 200 image/png
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contains the trimmed AnitaB.org card name and no `AnitaB.org ` trailing-space text
- git diff --check origin/main...HEAD

Refs #501 and #362.
