### PR TITLE
[codex] add rel to external card links

### DIFF
--- a/src/components/IssueList.astro
+++ b/src/components/IssueList.astro
@@ -120,7 +120,7 @@ if (repoInfo) {
   {issues.length > 0 ? (
     <div class="Issues-List">
       {issues.map((issue) => (
-        <a href={issue.html_url} target="_blank" class="Issue-Card">
+        <a href={issue.html_url} target="_blank" rel="noopener noreferrer" class="Issue-Card">
           <div class="Issue-Content">
             <div class="Issue-Title">{issue.title}</div>
             <div class="Issue-Meta">

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -14,7 +14,7 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
 ---
 
 <div class="Card-Container">
-  <a class="Card-Real-Link" href={projectLink} target="_blank">
+  <a class="Card-Real-Link" href={projectLink} target="_blank" rel="noopener noreferrer">
     <div class="Card-Header">
       <img
         class="Project-Logo"
@@ -219,4 +219,3 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     }
   }
 </style>
-


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to project-card links that open repository pages in a new tab
- add the same protection to issue-preview links that open GitHub issues in a new tab

## Why
These links already use `target="_blank"`; adding `rel` prevents the newly opened page from retaining access to the opener context and clears the remaining source-level new-tab link gap.

## Validation
- `rg -n "target=\"_blank\"(?![^>]*rel=)|target='_blank'(?![^>]*rel=)" src --pcre2` returned no matches
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- generated `dist/index.html` check found 168 `target="_blank"` links and 0 missing `noopener`/`noreferrer`
