### PR TITLE
[codex] dedupe tag filter options

### DIFF
--- a/src/components/ProjectList.astro
+++ b/src/components/ProjectList.astro
@@ -2,8 +2,19 @@
 import ProjectCard from './ProjectCard.astro';
 import { projectList } from '../data/projects.js';
 
-// Get all unique tags for filtering
-const allTags = [...new Set(projectList.flatMap(project => project.tags || []))].sort();
+// Get all unique tag values for filtering, ignoring capitalization differences.
+const allTags = [
+  ...projectList
+    .flatMap(project => project.tags || [])
+    .reduce((tags, tag) => {
+      const key = tag.toLowerCase();
+      if (!tags.has(key)) {
+        tags.set(key, tag);
+      }
+      return tags;
+    }, new Map<string, string>())
+    .values()
+].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
 ---
 
 <div id="container">


### PR DESCRIPTION
## Summary
- dedupe tag-filter options by their lowercase value before rendering the dropdown
- keep the first display label for each tag while preventing duplicate select values like `github` and `javascript`

## Why
The project data contains tags with capitalization differences, which can render repeated filter choices with the same value. This keeps the UI cleaner without rewriting the underlying project data.

## Validation
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- generated `dist/index.html` option check: 306 total options, 305 tag options, 0 duplicate non-empty option values
