### PR TITLE
[codex] fix Litefy description typo

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1082,7 +1082,7 @@ export const projectList = [
     imageSrc:
       "https://raw.githubusercontent.com/mathkruger/litefy/master/src/assets/logo.png",
     projectLink: "https://github.com/mathkruger/litefy/contribute",
-    description: "A lighweight Spotify client for low-end devices",
+    description: "A lightweight Spotify client for low-end devices",
     tags: ["OpenSource", "Angular", "HTML", "CSS", "Javascript", "Typescript"],
   },
   {


### PR DESCRIPTION
## Summary
- fix the Litefy project description typo from `lighweight` to `lightweight`
- restore the missing final newline in `src/data/projects.js`

## Why
The typo is visible in the rendered project card copy on the homepage.

## Validation
- imported `projectList` in Node and confirmed the Litefy description contains `lightweight` and not `lighweight`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- generated `dist/index.html` check confirmed the homepage contains the corrected Litefy copy and not the typo
