### PR TITLE
[codex] normalize funding project name

### DIFF
--- a/public/funding.json
+++ b/public/funding.json
@@ -14,7 +14,7 @@
   "projects": [
     {
       "guid": "first-contributions",
-      "name": "First contributions",
+      "name": "First Contributions",
       "description": "Help beginners learn how to contribute to open-source projects. It provides a simple and beginner-friendly way for users to understand the contribution workflow using Git and GitHub. We've had over 90,000 users since we started in 2016",
       "webpageUrl": {
         "url": "https://firstcontributions.github.io/",


### PR DESCRIPTION
## Summary
- normalize the project name in `public/funding.json` from `First contributions` to `First Contributions`

## Why
This keeps the public funding metadata aligned with the site title, manifest name, Open Graph metadata, and README casing.

## Validation
- parsed `public/funding.json` with Node and confirmed the `first-contributions` project name is `First Contributions`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- parsed generated `dist/funding.json` and confirmed the built project name is also `First Contributions`
