### PR TITLE
[codex] shorten generated page titles

### DIFF
--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -7,12 +7,10 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>
-    How to Contribute to Open Source: A Complete Guide for Beginners
-  </title>
+  <title>How to Contribute to Open Source: A Beginner Guide</title>
   <meta
     name="title"
-    content="How to Contribute to Open Source: A Complete Guide for Beginners"
+    content="How to Contribute to Open Source: A Beginner Guide"
   />
   <meta
     name="description"
@@ -31,7 +29,7 @@
   />
   <meta
     property="og:title"
-    content="How to Contribute to Open Source: A Complete Guide for Beginners"
+    content="How to Contribute to Open Source: A Beginner Guide"
   />
   <meta
     property="og:description"
@@ -50,7 +48,7 @@
   />
   <meta
     property="twitter:title"
-    content="How to Contribute to Open Source: A Complete Guide for Beginners"
+    content="How to Contribute to Open Source: A Beginner Guide"
   />
   <meta
     name="twitter:description"
@@ -83,7 +81,7 @@
     {
       "@context": "https://schema.org",
       "@type": "Article",
-      "headline": "How to Contribute to Open Source: A Complete Guide for Beginners",
+      "headline": "How to Contribute to Open Source: A Beginner Guide",
       "description": "Learn how to start contributing to open source projects with this comprehensive guide. Perfect for beginners, including step-by-step instructions, best practices, and expert tips.Learn how to contribute to open source with this beginner-friendly guide. Discover the benefits, steps, and best practices for making your first contribution.",
       "image": "https://firstcontributions.github.io/assets/preview-image.jpg",
       "author": {
@@ -108,7 +106,7 @@
     <article>
       <section>
         <h1>
-          How to Contribute to Open Source: A Comprehensive Guide for Beginners
+          How to Contribute to Open Source: A Beginner Guide
         </h1>
         <p>
           TL;DR if you prefer making your first pull request on GitHub right away, go to <a href="https://github.com/firstcontributions/first-contributions">first contributions</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,7 @@ import App from '../components/App.astro';
 ---
 
 <Layout 
-	title="First Contributions - Make Your First Open Source Contribution in 5 Minutes"
+	title="First Contributions - Make Your First Open Source Contribution"
 	description="Learn how to make your first open source contribution in just 5 minutes. Step-by-step guide for beginners with beginner-friendly projects and resources."
 	keywords="open source, github, contribute to open source, beginner programmer, first contribution, git, pull request, coding, software development, programming, learn to code"
 	url="https://firstcontributions.github.io/"


### PR DESCRIPTION
## Summary
- shorten the homepage `<title>` so it stays under common SEO title-length guidance
- shorten the open-source guide page title and matching title metadata/headline
- keep the article wording beginner-focused while avoiding generated `long-title` validation errors

Addresses #348

## Validation
- `git diff --check`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- generated title check: homepage title is 62 chars; guide title is 50 chars
- `pnpm dlx html-validate dist/index.html dist/contribute-to-opensource/index.html` no longer reports `long-title` errors; remaining reports are existing nested-anchor/article-lang issues covered by other PRs
