### PR TITLE
[codex] add Kyverno to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1458,4 +1458,12 @@ export const projectList = [
     description: "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
     tags: ["Python", "Automation", "Configuration Management"],
   },
+  {
+    name: "Kyverno",
+    imageSrc: "https://avatars.githubusercontent.com/u/68448710?s=200&v=4",
+    projectLink: "https://github.com/kyverno/kyverno/contribute",
+    description:
+      "Kyverno is a policy engine designed for Kubernetes, helping teams validate, mutate, generate, and clean up cluster resources.",
+    tags: ["Go", "Kubernetes", "Policy", "Cloud Native", "Good First Issue"],
+  },
 ];


### PR DESCRIPTION
## Summary
- add Kyverno to the beginner project suggestions
- point the card at Kyverno's GitHub `/contribute` page
- include the GitHub-hosted organization avatar and relevant tags for filtering

Addresses #1

## Validation
- `git diff --check`
- imported `projectList` from `src/data/projects.js` and confirmed Kyverno is present
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- generated `dist/index.html` contains the Kyverno name, contribute link, avatar URL, and `Good First Issue` tag
- GitHub API confirms `kyverno/kyverno` is public, unarchived, enabled, and has open `good first issue` items
- `https://github.com/kyverno/kyverno/contribute` returns HTTP 200
- avatar URL returns HTTP 200 `image/png`
