### PR TITLE
[codex] trim project search queries

### DIFF
--- a/src/components/ProjectList.astro
+++ b/src/components/ProjectList.astro
@@ -74,7 +74,7 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
 
     // Filter by search term
     if (searchValue.trim()) {
-      const searchTerm = searchValue.toLowerCase();
+      const searchTerm = searchValue.trim().toLowerCase();
       filtered = filtered.filter(project =>
         project.name.toLowerCase().includes(searchTerm) ||
         project.description.toLowerCase().includes(searchTerm) ||


### PR DESCRIPTION
## Summary
- trim whitespace from project search terms before matching
- preserve the existing lowercase search behavior
- avoid false zero-result states when users type accidental leading or trailing spaces

Addresses #501

## Validation
- `git diff --check`
- extracted inline script from `src/components/ProjectList.astro` and ran `node --check -`
- direct behavior check confirms ` react ` becomes `react` and still matches the React project
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
