### PR TITLE
[codex] add web app manifest id

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,6 +2,7 @@
   "short_name": "First Contributions",
   "name": "First Contributions - Make Your First Open Source Contribution",
   "description": "Learn how to make your first open source contribution in just 5 minutes. Step-by-step guide for beginners with beginner-friendly projects and resources.",
+  "id": "/",
   "icons": [
     {
       "src": "android-chrome-192x192.png",


### PR DESCRIPTION
## Summary
- add a stable root-relative `id` to the web app manifest
- keep it aligned with the existing root `start_url` and `scope`
- make the manifest identity explicit for browsers and app catalog tooling

Addresses #347

## Validation
- `git diff --check`
- parsed `public/manifest.json` and confirmed `id`, `start_url`, and `scope` are all `/`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- parsed generated `dist/manifest.json` and confirmed `id`, `start_url`, and `scope` are all `/`

## Reference
MDN documents the manifest `id` member as the unique identifier for a web app and recommends using a leading `/` for a root-relative identifier: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/id
