### PR TITLE
[codex] localize guide page styles

### DIFF
--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -73,10 +73,48 @@
     type="image/png"
     href="https://firstcontributions.github.io/assets/first-contributions-logo.svg"
   />
-  <link
-    rel="stylesheet"
-    href="https://unpkg.com/chota@0.9.2/dist/chota.min.css"
-  />
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+
+    body {
+      color: #1f2937;
+      margin: 0;
+    }
+
+    .container {
+      margin: 0 auto;
+      max-width: 64rem;
+      padding: 2rem 1rem;
+    }
+
+    h1,
+    h2,
+    h3 {
+      color: #111827;
+      line-height: 1.2;
+    }
+
+    h1 {
+      font-size: clamp(2rem, 5vw, 3.5rem);
+      margin-top: 0;
+    }
+
+    h2 {
+      margin-top: 2.5rem;
+    }
+
+    a {
+      color: #2563eb;
+    }
+
+    li {
+      margin-bottom: 0.75rem;
+    }
+  </style>
 
   <!-- Structured Data / Schema.org -->
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- remove the guide page dependency on the external unpkg/chota stylesheet
- add a small local style block for readable article typography and layout
- avoid one third-party CSS request on the open-source guide page

Addresses #470

## Validation
- `git diff --check`
- source check confirms `src/pages/contribute-to-opensource.astro` no longer references `unpkg.com/chota`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- generated `dist/contribute-to-opensource/index.html` contains no `unpkg` or `chota.min.css` reference
- generated guide HTML still contains the guide title and local container styling
