### PR TITLE
[codex] structure guide challenge tips

### DIFF
--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -271,10 +271,13 @@
             week can make a difference.
           </li>
           <li>
-            Navigating Large Codebases: Break down the learning process: - Start
-            by reading the documentation thoroughly - Focus on understanding one
-            component at a time - Use debugging tools to trace code execution -
-            Don't hesitate to ask for clarification
+            Navigating Large Codebases: Break down the learning process:
+            <ul>
+              <li>Start by reading the documentation thoroughly.</li>
+              <li>Focus on understanding one component at a time.</li>
+              <li>Use debugging tools to trace code execution.</li>
+              <li>Don't hesitate to ask for clarification.</li>
+            </ul>
           </li>
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- replace inline dash-separated guidance in the guide page with a semantic nested list
- make the “Navigating Large Codebases” tips easier to scan
- preserve the existing Common Challenges section and copy intent

Addresses #501

## Validation
- `git diff --check`
- source check confirms the inline `process: - Start` dash-run text is removed
- source check confirms the four large-codebase tips now render as list items
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- generated guide HTML keeps the Common Challenges section and includes the nested tip list
