### PR TITLE
[codex] add Rspack to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1458,4 +1458,12 @@ export const projectList = [
     description: "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
     tags: ["Python", "Automation", "Configuration Management"],
   },
+  {
+    name: "Rspack",
+    imageSrc: "https://avatars.githubusercontent.com/u/87694465?s=200&v=4",
+    projectLink: "https://github.com/web-infra-dev/rspack/contribute",
+    description:
+      "Rspack is a fast Rust-based bundler for the web with a modernized webpack-compatible API.",
+    tags: ["Rust", "JavaScript", "TypeScript", "Bundler", "Good First Issue"],
+  },
 ];


### PR DESCRIPTION
## Summary
- add Rspack to the beginner project suggestions
- point the card at Rspack's GitHub `/contribute` page
- include the GitHub-hosted organization avatar and relevant web bundler tags

Addresses #1

## Validation
- `git diff --check`
- imported `projectList` from `src/data/projects.js` and confirmed Rspack is present
- `GITHUB_TOKEN=$(gh auth token) pnpm build`
- generated `dist/index.html` contains the Rspack name, contribute link, avatar URL, and `Good First Issue` tag
- GitHub API confirms `web-infra-dev/rspack` is public, unarchived, enabled, and has an open `good first issue`
- `https://github.com/web-infra-dev/rspack/contribute` returns HTTP 200
- avatar URL returns HTTP 200 `image/png`
