### PR TITLE
[codex] add Open WebUI to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1458,4 +1458,12 @@ export const projectList = [
     description: "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
     tags: ["Python", "Automation", "Configuration Management"],
   },
+  {
+    name: "Open WebUI",
+    imageSrc: "https://avatars.githubusercontent.com/u/158137808?v=4",
+    projectLink: "https://github.com/open-webui/open-webui/contribute",
+    description:
+      "Open WebUI is a user-friendly AI interface for running and managing self-hosted AI workflows.",
+    tags: ["Python", "Svelte", "TypeScript", "AI", "Self Hosted"],
+  },
 ];


### PR DESCRIPTION
## Summary
- add Open WebUI to the project suggestions list
- link the card to the Open WebUI GitHub contributor page
- include GitHub avatar, concise description, and searchable language/topic tags

## Validation
- GitHub API reports open-webui/open-webui is public, unarchived, and on main
- https://github.com/open-webui/open-webui/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/158137808?v=4 returns HTTP 200
- open-webui/open-webui has open good first issue-labeled issues
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Open WebUI card and contributor link before restoring generated files

Addresses #1
