### PR TITLE
[codex] remove duplicate Open Source Diversity card

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -722,24 +722,6 @@ export const projectList = [
     ],
   },
   {
-    name: "Open Source Diversity",
-    imageSrc: "https://avatars1.githubusercontent.com/u/31018274?s=200&v=4",
-    projectLink:
-      "https://github.com/opensourcediversity/opensourcediversity.org/contribute",
-    description:
-      "For more diversity & inclusion in free & open source software communities 😊",
-    tags: [
-      "javascript",
-      "html",
-      "css",
-      "diversity",
-      "inclusion",
-      "🎉",
-      "web",
-      "community",
-    ],
-  },
-  {
     name: "Bitcoin",
     imageSrc:
       "https://img.rawpixel.com/s3fs-private/rawpixel_images/website_content/v211-mint-aum-currency-13.jpg?auto=format&bg=F4F4F3&con=3&cs=srgb&dpr=1&fm=jpg&ixlib=php-1.1.0&mark=rawpixel-watermark.png&markalpha=90&markpad=13&markscale=10&markx=25&q=75&usm=15&vib=3&w=1000&s=435abda621bceebc1362c7e657e06c79",


### PR DESCRIPTION
## Summary
- remove the second identical Open Source Diversity project card
- keep the earlier Open Source Diversity entry with the same live contributor link, avatar, description, and tags
- reduce duplicate cards in the project list UI

## Validation
- Open Source Diversity source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html Open Source Diversity count is 1 before restoring generated files
- contributor link and avatar both return HTTP 200

Related to #501
