### PR TITLE
[codex] add Supabase to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1445,6 +1445,14 @@ export const projectList = [
     tags: ["Go", "React", "Chat", "Collaboration"],
   },
   {
+    name: "Supabase",
+    imageSrc: "https://avatars.githubusercontent.com/u/54469796?v=4",
+    projectLink: "https://github.com/supabase/supabase/contribute",
+    description:
+      "Supabase is an open source Postgres development platform for building web, mobile, and AI applications.",
+    tags: ["TypeScript", "Postgres", "Database", "Backend", "Cloud"],
+  },
+  {
     name: "Terraform",
     imageSrc: "https://avatars.githubusercontent.com/u/11051457?s=200&v=4",
     projectLink: "https://github.com/hashicorp/terraform",


### PR DESCRIPTION
## Summary
- add Supabase to the project suggestions list
- link the card to the Supabase GitHub contributor page
- include GitHub avatar, concise description, and searchable language/topic tags

## Validation
- GitHub API reports supabase/supabase is public, unarchived, and on master
- https://github.com/supabase/supabase/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/54469796?v=4 returns HTTP 200
- supabase/supabase has an open good first issue-labeled issue
- Supabase source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Supabase card and contributor link before restoring generated files

Addresses #1
