### PR TITLE
[codex] remove stale duplicate project cards

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -997,14 +997,6 @@ export const projectList = [
     ],
   },
   {
-    name: "Mattermost",
-    imageSrc:
-      "https://raw.githubusercontent.com/mattermost/mattermost-handbook/3b54c2cd1f823d1ea012ce45d1baa61fb4fbedbc/.gitbook/assets/branding/logo-downloads/mattermost-logo-vertical-blue.png",
-    projectLink: "https://github.com/mattermost/mattermost-server/contribute",
-    description: "Open source Slack-alternative for DevOps teams",
-    tags: ["Go", "Javascript", "React", "React Native"],
-  },
-  {
     name: "Leapcode",
     imageSrc: "https://avatars1.githubusercontent.com/u/66108516?s=200&v=4",
     projectLink: "https://github.com/Leapcode-Open/leapcode-frontend/issues",
@@ -1020,14 +1012,6 @@ export const projectList = [
     description:
       "This is an example that how to use Markdown creating a dungeon.",
     tags: ["Markdown", "React", "Gatsby", "Good First Issue", "Beginner"],
-  },
-  {
-    name: "Ansible",
-    imageSrc: "https://avatars1.githubusercontent.com/u/1507452?s=200&v=4",
-    projectLink: "https://docs.ansible.com/ansible/latest/community/index.html",
-    description:
-      "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
-    tags: ["Python", "Automated-Testingg", "Beginner"],
   },
   {
     name: "start-here-guidelines",


### PR DESCRIPTION
## Summary
- remove older duplicate Mattermost and Ansible project cards
- keep the current Mattermost and Ansible entries already present later in the list
- reduce repeated project cards in the rendered project list

## Validation
- Mattermost source count is 1 via src/data/projects.js import
- Ansible source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html renders one Mattermost card and one Ansible card before restoring generated files

Related to #501
