### PR TITLE
[codex] add Zed to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1431,6 +1431,14 @@ export const projectList = [
     tags: ["C++", "Game Development", "Game Engine", "GDScript"],
   },
   {
+    name: "Zed",
+    imageSrc: "https://avatars.githubusercontent.com/u/79345384?v=4",
+    projectLink: "https://github.com/zed-industries/zed/contribute",
+    description:
+      "Zed is a high-performance, multiplayer code editor built for fast collaborative development.",
+    tags: ["Rust", "Editor", "Collaboration", "AI"],
+  },
+  {
     name: "Hugo",
     imageSrc: "https://avatars.githubusercontent.com/u/1048514?s=200&v=4",
     projectLink: "https://github.com/gohugoio/hugo",


### PR DESCRIPTION
## Summary
- add Zed to the project suggestions list
- link the card to the Zed GitHub contributor page
- include GitHub avatar, concise description, and searchable language/topic tags

## Validation
- GitHub API reports zed-industries/zed is public, unarchived, and on main
- https://github.com/zed-industries/zed/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/79345384?v=4 returns HTTP 200
- zed-industries/zed has open issues labeled .contrib/good first issue
- Zed source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Zed card and contributor link before restoring generated files

Addresses #1
