### PR TITLE
[codex] add TanStack Query to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -139,6 +139,14 @@ export const projectList = [
     tags: ["JavaScript", "React", "React Native", "Mobile"],
   },
   {
+    name: "TanStack Query",
+    imageSrc: "https://avatars.githubusercontent.com/u/72518640?v=4",
+    projectLink: "https://github.com/TanStack/query/contribute",
+    description:
+      "TanStack Query provides powerful asynchronous state management and data fetching utilities for web applications.",
+    tags: ["TypeScript", "JavaScript", "React", "Vue", "Svelte"],
+  },
+  {
     name: "Typescript",
     imageSrc:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Typescript_logo_2020.svg/1200px-Typescript_logo_2020.svg.png",


### PR DESCRIPTION
## Summary
- add TanStack Query to the project suggestions list
- link the card to the TanStack Query GitHub contributor page
- include GitHub avatar, concise description, and searchable framework/language tags

## Validation
- GitHub API reports TanStack/query is public, unarchived, and on main
- https://github.com/TanStack/query/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/72518640?v=4 returns HTTP 200
- TanStack/query has open help wanted issues
- TanStack Query source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the TanStack Query card and contributor link before restoring generated files

Addresses #1
