### PR TITLE
[codex] add Vitest to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -184,6 +184,13 @@ export const projectList = [
     tags: ["Testing", "JavaScript", "React"],
   },
   {
+    name: "Vitest",
+    imageSrc: "https://avatars.githubusercontent.com/u/95747107?v=4",
+    projectLink: "https://github.com/vitest-dev/vitest/contribute",
+    description: "Vitest is a fast, Vite-powered testing framework for modern JavaScript and TypeScript projects.",
+    tags: ["Testing", "JavaScript", "TypeScript", "Vite"],
+  },
+  {
     name: "Gauge",
     imageSrc:
       "https://avatars3.githubusercontent.com/u/7044589?s=400&u=8d2ce328da30e81978c303fdb31a2a7a1f0328e3&v=4",


### PR DESCRIPTION
## Summary
- add Vitest to the project suggestions list
- link the card to the Vitest GitHub contributor page
- include GitHub avatar, concise description, and testing/framework tags

## Validation
- GitHub API reports vitest-dev/vitest is public, unarchived, and on main
- https://github.com/vitest-dev/vitest/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/95747107?v=4 returns HTTP 200
- vitest-dev/vitest has an open help wanted issue
- Vitest source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Vitest card and contributor link before restoring generated files

Addresses #1
