### PR TITLE
[codex] add ESLint to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -236,6 +236,13 @@ export const projectList = [
     tags: ["JavaScript", "HTML", "Node.js", "Template Engine"],
   },
   {
+    name: "ESLint",
+    imageSrc: "https://avatars.githubusercontent.com/u/6019716?v=4",
+    projectLink: "https://github.com/eslint/eslint/contribute",
+    description: "ESLint helps developers find and fix problems in JavaScript and TypeScript code.",
+    tags: ["JavaScript", "TypeScript", "Linting", "Developer Tools"],
+  },
+  {
     name: "Elasticsearch",
     imageSrc: "https://avatars2.githubusercontent.com/u/6764390?v=3&s=100",
     projectLink: "https://github.com/elastic/elasticsearch/contribute",


### PR DESCRIPTION
## Summary
- add ESLint to the project suggestions list
- link the card to the ESLint GitHub contributor page
- include GitHub avatar, concise description, and JavaScript/TypeScript tooling tags

## Validation
- GitHub API reports eslint/eslint is public, unarchived, and on main
- https://github.com/eslint/eslint/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/6019716?v=4 returns HTTP 200
- eslint/eslint has an open help wanted issue
- ESLint source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the ESLint card and contributor link before restoring generated files

Addresses #1
