### PR TITLE
[codex] add Prettier to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -236,6 +236,13 @@ export const projectList = [
     tags: ["JavaScript", "HTML", "Node.js", "Template Engine"],
   },
   {
+    name: "Prettier",
+    imageSrc: "https://avatars.githubusercontent.com/u/25822731?v=4",
+    projectLink: "https://github.com/prettier/prettier/contribute",
+    description: "Prettier is an opinionated code formatter for consistent project style.",
+    tags: ["JavaScript", "TypeScript", "Formatting", "Developer Tools"],
+  },
+  {
     name: "Elasticsearch",
     imageSrc: "https://avatars2.githubusercontent.com/u/6764390?v=3&s=100",
     projectLink: "https://github.com/elastic/elasticsearch/contribute",


### PR DESCRIPTION
## Summary
- add Prettier to the project suggestions list
- link the card to the Prettier GitHub contributor page
- include GitHub avatar, concise description, and formatting/tooling tags

## Validation
- GitHub API reports prettier/prettier is public, unarchived, and on main
- https://github.com/prettier/prettier/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/25822731?v=4 returns HTTP 200
- prettier/prettier has open help wanted issues
- Prettier source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Prettier card and contributor link before restoring generated files

Addresses #1
