### PR TITLE
[codex] add Bun to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -331,6 +331,14 @@ export const projectList = [
     tags: ["JavaScript", "Node.js", "Runtime"],
   },
   {
+    name: "Bun",
+    imageSrc: "https://avatars.githubusercontent.com/u/108928776?v=4",
+    projectLink: "https://github.com/oven-sh/bun/contribute",
+    description:
+      "Bun is an all-in-one JavaScript runtime, bundler, test runner, and package manager.",
+    tags: ["JavaScript", "TypeScript", "Runtime", "Bundler", "Testing"],
+  },
+  {
     name: "Semantic-UI-React",
     imageSrc: "https://reactnative.dev/img/header_logo.svg",
     projectLink: "https://github.com/Semantic-Org/Semantic-UI-React/contribute",


### PR DESCRIPTION
## Summary
- add Bun to the project suggestions list
- link the card to the Bun GitHub contributor page
- include GitHub avatar, concise description, and JavaScript runtime/tooling tags

## Validation
- GitHub API reports oven-sh/bun is public, unarchived, and on main
- https://github.com/oven-sh/bun/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/108928776?v=4 returns HTTP 200
- oven-sh/bun has open good first issue-labeled issues
- Bun source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Bun card and contributor link before restoring generated files

Addresses #1
