### PR TITLE
[codex] add Nushell to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -288,6 +288,13 @@ export const projectList = [
     tags: ["PowerShell", "Shell", "Cross Platform"],
   },
   {
+    name: "Nushell",
+    imageSrc: "https://avatars.githubusercontent.com/u/50749515?v=4",
+    projectLink: "https://github.com/nushell/nushell/contribute",
+    description: "Nushell is a modern shell that treats pipelines as structured data.",
+    tags: ["Rust", "Shell", "CLI", "Cross Platform"],
+  },
+  {
     name: "Webpack",
     imageSrc: "https://avatars3.githubusercontent.com/u/2105791?v=3&s=100",
     projectLink: "https://github.com/webpack/webpack/contribute",


### PR DESCRIPTION
## Summary
- add Nushell to the project suggestions list
- link the card to the Nushell GitHub contributor page
- include GitHub avatar, concise description, and shell/CLI tags

## Validation
- GitHub API reports nushell/nushell is public, unarchived, and on main
- https://github.com/nushell/nushell/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/50749515?v=4 returns HTTP 200
- nushell/nushell has open good first issue-labeled issues
- Nushell source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Nushell card and contributor link before restoring generated files

Addresses #1
