### PR TITLE
[codex] add pnpm to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -523,6 +523,13 @@ export const projectList = [
     tags: ["Javascript", "Shell", "CSS", "HTML", "Rust"],
   },
   {
+    name: "pnpm",
+    imageSrc: "https://avatars.githubusercontent.com/u/21320719?v=4",
+    projectLink: "https://github.com/pnpm/pnpm/contribute",
+    description: "pnpm is a fast, disk space efficient package manager for JavaScript projects.",
+    tags: ["JavaScript", "Package Manager", "Node.js", "CLI"],
+  },
+  {
     name: "openEBS",
     imageSrc: "https://avatars1.githubusercontent.com/u/20769039?s=200&v=4",
     projectLink: "https://github.com/openebs/",


### PR DESCRIPTION
## Summary
- add pnpm to the project suggestions list
- link the card to the pnpm GitHub contributor page
- include GitHub avatar, concise description, and package-manager tags

## Validation
- GitHub API reports pnpm/pnpm is public, unarchived, and on main
- https://github.com/pnpm/pnpm/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/21320719?v=4 returns HTTP 200
- pnpm/pnpm has open good first issue-labeled issues
- pnpm source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the pnpm card and contributor link before restoring generated files

Addresses #1
