### PR TITLE
[codex] add Tauri to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -432,6 +432,14 @@ export const projectList = [
     tags: ["JavaScript", "Electron", "Desktop", "Cross Platform"],
   },
   {
+    name: "Tauri",
+    imageSrc: "https://avatars.githubusercontent.com/u/54536011?v=4",
+    projectLink: "https://github.com/tauri-apps/tauri/contribute",
+    description:
+      "Tauri helps developers build smaller, faster, and more secure desktop and mobile apps with web frontends.",
+    tags: ["Rust", "JavaScript", "Desktop", "Mobile", "Cross Platform"],
+  },
+  {
     name: "Oppia",
     imageSrc:
       "https://www.oppia.org/build/assets/images/logo/288x128_logo_mint.42f8d38467fe745205b3374b33668068.png",


### PR DESCRIPTION
## Summary
- add Tauri to the project suggestions list
- link the card to the Tauri GitHub contributor page
- include GitHub avatar, concise description, and desktop/mobile app tags

## Validation
- GitHub API reports tauri-apps/tauri is public, unarchived, and on dev
- https://github.com/tauri-apps/tauri/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/54536011?v=4 returns HTTP 200
- tauri-apps/tauri has open help wanted issues
- Tauri source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Tauri card and contributor link before restoring generated files

Addresses #1
