### PR TITLE
[codex] add Mermaid to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -910,6 +910,14 @@ export const projectList = [
     ],
   },
   {
+    name: "Mermaid",
+    imageSrc: "https://avatars.githubusercontent.com/u/57169982?v=4",
+    projectLink: "https://github.com/mermaid-js/mermaid/contribute",
+    description:
+      "Mermaid creates diagrams and visualizations from text definitions, similar to Markdown.",
+    tags: ["JavaScript", "TypeScript", "Diagrams", "Visualization"],
+  },
+  {
     name: "FontAwesome",
     imageSrc: "https://avatars1.githubusercontent.com/u/1505683?s=200&v=4",
     projectLink: "https://github.com/FortAwesome/Font-Awesome/contribute",


### PR DESCRIPTION
## Summary
- add Mermaid to the project suggestions list
- link the card to the Mermaid GitHub contributor page
- include GitHub avatar, concise description, and diagram/visualization tags

## Validation
- GitHub API reports mermaid-js/mermaid is public, unarchived, and on develop
- https://github.com/mermaid-js/mermaid/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/57169982?v=4 returns HTTP 200
- mermaid-js/mermaid has open Good first issue-labeled issues
- Mermaid source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Mermaid card and contributor link before restoring generated files

Addresses #1
