### PR TITLE
[codex] add Caddy to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -790,6 +790,14 @@ export const projectList = [
     ],
   },
   {
+    name: "Caddy",
+    imageSrc: "https://avatars.githubusercontent.com/u/12955528?v=4",
+    projectLink: "https://github.com/caddyserver/caddy/contribute",
+    description:
+      "Caddy is a fast, extensible web server with automatic HTTPS and modern HTTP support.",
+    tags: ["Go", "HTTP", "Web Server", "Networking"],
+  },
+  {
     name: "Conda",
     imageSrc: "https://avatars.githubusercontent.com/u/6392739?s=200&v=4",
     projectLink: "https://github.com/conda",


### PR DESCRIPTION
## Summary
- add Caddy to the project suggestions list
- link the card to the Caddy GitHub contributor page
- include GitHub avatar, concise description, and web-server/networking tags

## Validation
- GitHub API reports caddyserver/caddy is public, unarchived, and on master
- https://github.com/caddyserver/caddy/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/12955528?v=4 returns HTTP 200
- caddyserver/caddy has open good first issue-labeled issues
- Caddy source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Caddy card and contributor link before restoring generated files

Addresses #1
