### PR TITLE
[codex] add Helix to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -317,6 +317,13 @@ export const projectList = [
     tags: ["Vim", "Editor", "Cross Platform"],
   },
   {
+    name: "Helix",
+    imageSrc: "https://avatars.githubusercontent.com/u/66235900?v=4",
+    projectLink: "https://github.com/helix-editor/helix/contribute",
+    description: "Helix is a post-modern modal text editor focused on powerful editing workflows.",
+    tags: ["Rust", "Editor", "CLI", "Cross Platform"],
+  },
+  {
     name: "freeCodeCamp",
     imageSrc: "https://avatars0.githubusercontent.com/u/9892522?v=3&s=100",
     projectLink: "https://github.com/freeCodeCamp/freeCodeCamp/contribute",


### PR DESCRIPTION
## Summary
- add Helix to the project suggestions list
- link the card to the Helix GitHub contributor page
- include GitHub avatar, concise description, and editor/CLI tags

## Validation
- GitHub API reports helix-editor/helix is public, unarchived, and on master
- https://github.com/helix-editor/helix/contribute returns HTTP 200
- https://avatars.githubusercontent.com/u/66235900?v=4 returns HTTP 200
- helix-editor/helix has open easy-labeled issues
- Helix source count is 1 via src/data/projects.js import
- git diff --check
- GITHUB_TOKEN=$(gh auth token) pnpm build
- generated dist/index.html contained the Helix card and contributor link before restoring generated files

Addresses #1
