### PR TITLE
[codex] add Excalidraw to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -917,6 +917,14 @@ export const projectList = [
     tags: ["SVG", "CSS", "font"],
   },
   {
+    name: "Excalidraw",
+    imageSrc: "https://avatars.githubusercontent.com/u/59452120?v=4",
+    projectLink: "https://github.com/excalidraw/excalidraw/contribute",
+    description:
+      "Excalidraw is a virtual whiteboard for sketching hand-drawn style diagrams.",
+    tags: ["TypeScript", "React", "Whiteboard", "Diagrams"],
+  },
+  {
     name: "TallyCTF",
     imageSrc:
       "https://raw.githubusercontent.com/CyberNinjas/TallyCTF/master/modules/core/client/img/brand/Tallylogo_1.png",


### PR DESCRIPTION
## Summary
- add Excalidraw to the project suggestions list
- link to Excalidraw contributors through GitHub /contribute
- include the project avatar and relevant TypeScript/React/whiteboard tags

## Validation
- verified the Excalidraw project entry is unique in src/data/projects.js
- verified https://github.com/excalidraw/excalidraw/contribute returns 200
- verified the project avatar returns 200
- verified Excalidraw has open beginner-friendly issues
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Excalidraw card/link

Addresses #1
