### PR TITLE
[codex] add fish shell to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1296,6 +1296,14 @@ export const projectList = [
     tags: ["Python", "Shell", "Automation"],
   },
   {
+    name: "fish shell",
+    imageSrc: "https://avatars.githubusercontent.com/u/1828073?v=4",
+    projectLink: "https://github.com/fish-shell/fish-shell/contribute",
+    description:
+      "fish is a smart and user-friendly command line shell for Linux, macOS, and the rest of the family.",
+    tags: ["C++", "Shell", "Command Line", "Terminal"],
+  },
+  {
     name: "aprenda-go-com-testes",
     projectLink: "https://github.com/larien/aprenda-go-com-testes",
     imageSrc:


### PR DESCRIPTION
## Summary
- add fish shell to the project suggestions list
- link to the fish-shell contributors page through GitHub /contribute
- include the project avatar and shell/terminal tags

## Validation
- verified the fish shell project entry is unique in src/data/projects.js
- verified https://github.com/fish-shell/fish-shell/contribute returns 200
- verified the project avatar returns 200
- verified fish-shell has an open good first issue
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered fish shell card/link

Addresses #1
