### PR TITLE
[codex] add Jellyfin to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1431,6 +1431,14 @@ export const projectList = [
     tags: ["C++", "Game Development", "Game Engine", "GDScript"],
   },
   {
+    name: "Jellyfin",
+    imageSrc: "https://avatars.githubusercontent.com/u/45698031?v=4",
+    projectLink: "https://github.com/jellyfin/jellyfin/contribute",
+    description:
+      "Jellyfin is a free software media system for managing and streaming media.",
+    tags: ["C#", "Media Server", "Streaming", "Self Hosted"],
+  },
+  {
     name: "Hugo",
     imageSrc: "https://avatars.githubusercontent.com/u/1048514?s=200&v=4",
     projectLink: "https://github.com/gohugoio/hugo",


### PR DESCRIPTION
## Summary
- add Jellyfin to the project suggestions list
- link to Jellyfin contributors through GitHub /contribute
- include the project avatar and relevant media-server tags

## Validation
- verified the Jellyfin project entry is unique in src/data/projects.js
- verified https://github.com/jellyfin/jellyfin/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Jellyfin has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Jellyfin card/link

Addresses #1
