### PR TITLE
[codex] add Qwik to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1417,6 +1417,14 @@ export const projectList = [
     tags: ["JavaScript", "TypeScript", "Frontend", "Compiler"],
   },
   {
+    name: "Qwik",
+    imageSrc: "https://avatars.githubusercontent.com/u/138123704?v=4",
+    projectLink: "https://github.com/QwikDev/qwik/contribute",
+    description:
+      "Qwik is a web framework focused on instant loading and resumable applications.",
+    tags: ["TypeScript", "JavaScript", "Frontend", "Web Framework"],
+  },
+  {
     name: "FastAPI",
     imageSrc: "https://avatars.githubusercontent.com/u/32770743?s=200&v=4",
     projectLink: "https://github.com/tiangolo/fastapi",


### PR DESCRIPTION
## Summary
- add Qwik to the project suggestions list
- link to Qwik contributors through GitHub /contribute
- include the project avatar and relevant frontend framework tags

## Validation
- verified the Qwik project entry is unique in src/data/projects.js
- verified https://github.com/QwikDev/qwik/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Qwik has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Qwik card/link

Addresses #1
