### PR TITLE
[codex] add Lit to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1417,6 +1417,14 @@ export const projectList = [
     tags: ["JavaScript", "TypeScript", "Frontend", "Compiler"],
   },
   {
+    name: "Lit",
+    imageSrc: "https://avatars.githubusercontent.com/u/18489846?v=4",
+    projectLink: "https://github.com/lit/lit/contribute",
+    description:
+      "Lit is a simple library for building fast, lightweight web components.",
+    tags: ["TypeScript", "JavaScript", "Web Components", "Frontend"],
+  },
+  {
     name: "FastAPI",
     imageSrc: "https://avatars.githubusercontent.com/u/32770743?s=200&v=4",
     projectLink: "https://github.com/tiangolo/fastapi",


### PR DESCRIPTION
## Summary
- add Lit to the project suggestions list
- link to Lit contributors through GitHub /contribute
- include the project avatar and relevant web-components tags

## Validation
- verified the Lit project entry is unique in src/data/projects.js
- verified https://github.com/lit/lit/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Lit has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Lit card/link

Addresses #1
