### PR TITLE
[codex] add Apache Airflow to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -72,6 +72,14 @@ export const projectList = [
     tags: ["Python", "Data Science", "Machine Learning", "ETL", "DAG"],
   },
   {
+    name: "Apache Airflow",
+    imageSrc: "https://avatars.githubusercontent.com/u/47359?v=4",
+    projectLink: "https://github.com/apache/airflow/contribute",
+    description:
+      "Apache Airflow is a platform to programmatically author, schedule, and monitor workflows.",
+    tags: ["Python", "Workflow", "Data Engineering", "Automation"],
+  },
+  {
     name: "altair",
     imageSrc:
       "https://raw.githubusercontent.com/altair-graphql/altair/master/icons/favicon-96x96.png",


### PR DESCRIPTION
## Summary
- add Apache Airflow to the project suggestions list
- link to Airflow contributors through GitHub /contribute
- include the Apache avatar and relevant workflow/data-engineering tags

## Validation
- verified the Apache Airflow project entry is unique in src/data/projects.js
- verified https://github.com/apache/airflow/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Apache Airflow has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Apache Airflow card/link

Addresses #1
