### PR TITLE
[codex] add OpenTelemetry JavaScript to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1403,6 +1403,14 @@ export const projectList = [
     ],
   },
   {
+    name: "OpenTelemetry JavaScript",
+    imageSrc: "https://avatars.githubusercontent.com/u/49998002?v=4",
+    projectLink: "https://github.com/open-telemetry/opentelemetry-js/contribute",
+    description:
+      "OpenTelemetry JavaScript provides observability APIs and SDKs for JavaScript applications.",
+    tags: ["TypeScript", "JavaScript", "Observability", "Telemetry"],
+  },
+  {
     name: "MeiliSearch",
     imageSrc: "https://avatars.githubusercontent.com/u/43250847?s=200&v=4",
     projectLink: "https://github.com/meilisearch/meilisearch",


### PR DESCRIPTION
## Summary
- add OpenTelemetry JavaScript to the project suggestions list
- link to OpenTelemetry JS contributors through GitHub /contribute
- include the project avatar and relevant observability tags

## Validation
- verified the OpenTelemetry JavaScript project entry is unique in src/data/projects.js
- verified https://github.com/open-telemetry/opentelemetry-js/contribute returns 200
- verified the project avatar returns 200 image/png
- verified OpenTelemetry JavaScript has an open good first issue item
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered OpenTelemetry JavaScript card/link

Addresses #1
