### PR TITLE
[codex] open guide GitHub link safely

### DIFF
--- a/src/pages/contribute-to-opensource.astro
+++ b/src/pages/contribute-to-opensource.astro
@@ -111,7 +111,12 @@
           How to Contribute to Open Source: A Comprehensive Guide for Beginners
         </h1>
         <p>
-          TL;DR if you prefer making your first pull request on GitHub right away, go to <a href="https://github.com/firstcontributions/first-contributions">first contributions</a>
+          TL;DR if you prefer making your first pull request on GitHub right
+          away, go to <a
+            href="https://github.com/firstcontributions/first-contributions"
+            target="_blank"
+            rel="noopener noreferrer">first contributions</a
+          >
         </p>
         <p>
           Contributing to open source is one of the most rewarding ways to grow


### PR DESCRIPTION
## Summary
- make the guide page TL;DR GitHub link open like a safe external link
- add rel="noopener noreferrer" alongside target="_blank"
- keep the change scoped to the standalone guide page copy

## Validation
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/contribute-to-opensource/index.html renders the TL;DR GitHub link with target="_blank" and rel="noopener noreferrer"

Refs #347
Refs #501
