### PR TITLE
[codex] add Prisma to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -61,6 +61,14 @@ export const projectList = [
     description: "Drag & Drop internal tool builder",
     tags: ["UI", "Database", "Editor"],
   },
+  {
+    name: "Prisma",
+    imageSrc: "https://avatars.githubusercontent.com/u/17219288?v=4",
+    projectLink: "https://github.com/prisma/prisma/contribute",
+    description:
+      "Prisma is a next-generation ORM for Node.js and TypeScript applications.",
+    tags: ["TypeScript", "Node.js", "Database", "ORM"],
+  },
 
   {
     name: "Hamilton",


### PR DESCRIPTION
## Summary
- add Prisma to the project suggestions list
- link to Prisma contributors through GitHub /contribute
- include the project avatar and relevant TypeScript/database tags

## Validation
- verified the Prisma project entry is unique in src/data/projects.js
- verified https://github.com/prisma/prisma/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Prisma has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Prisma card/link

Addresses #1
