### PR TITLE
[codex] add Fastify to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -331,6 +331,14 @@ export const projectList = [
     tags: ["JavaScript", "Node.js", "Runtime"],
   },
   {
+    name: "Fastify",
+    imageSrc: "https://avatars.githubusercontent.com/u/24939410?v=4",
+    projectLink: "https://github.com/fastify/fastify/contribute",
+    description:
+      "Fastify is a fast and low-overhead web framework for Node.js.",
+    tags: ["JavaScript", "Node.js", "Web Framework", "API"],
+  },
+  {
     name: "Semantic-UI-React",
     imageSrc: "https://reactnative.dev/img/header_logo.svg",
     projectLink: "https://github.com/Semantic-Org/Semantic-UI-React/contribute",


### PR DESCRIPTION
## Summary
- add Fastify to the project suggestions list
- link to Fastify contributors through GitHub /contribute
- include the project avatar and relevant Node.js web framework tags

## Validation
- verified the Fastify project entry is unique in src/data/projects.js
- verified https://github.com/fastify/fastify/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Fastify has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Fastify card/link

Addresses #1
