### PR TITLE
[codex] add marimo to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -72,6 +72,14 @@ export const projectList = [
     tags: ["Python", "Data Science", "Machine Learning", "ETL", "DAG"],
   },
   {
+    name: "marimo",
+    imageSrc: "https://avatars.githubusercontent.com/u/98563464?v=4",
+    projectLink: "https://github.com/marimo-team/marimo/contribute",
+    description:
+      "marimo is a reactive Python notebook for reproducible experiments and apps.",
+    tags: ["Python", "Notebook", "Data Science", "Reactive"],
+  },
+  {
     name: "altair",
     imageSrc:
       "https://raw.githubusercontent.com/altair-graphql/altair/master/icons/favicon-96x96.png",


### PR DESCRIPTION
## Summary
- add marimo to the project suggestions list
- link to marimo contributors through GitHub /contribute
- include the project avatar and relevant Python notebook tags

## Validation
- verified the marimo project entry is unique in src/data/projects.js
- verified https://github.com/marimo-team/marimo/contribute returns 200
- verified the project avatar returns 200 image/png
- verified marimo has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered marimo card/link

Addresses #1
