### PR TITLE
[codex] add Strapi to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -61,6 +61,14 @@ export const projectList = [
     description: "Drag & Drop internal tool builder",
     tags: ["UI", "Database", "Editor"],
   },
+  {
+    name: "Strapi",
+    imageSrc: "https://avatars.githubusercontent.com/u/19872173?v=4",
+    projectLink: "https://github.com/strapi/strapi/contribute",
+    description:
+      "Strapi is an open-source headless CMS for building customizable APIs.",
+    tags: ["JavaScript", "CMS", "API", "Node.js"],
+  },
 
   {
     name: "Hamilton",


### PR DESCRIPTION
## Summary
- add Strapi to the project suggestions list
- link to Strapi contributors through GitHub /contribute
- include the project avatar and relevant CMS/API tags

## Validation
- verified the Strapi project entry is unique in src/data/projects.js
- verified https://github.com/strapi/strapi/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Strapi has an open good first issue item
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Strapi card/link

Addresses #1
