### PR TITLE
[codex] add Hoppscotch to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -61,6 +61,14 @@ export const projectList = [
     description: "Drag & Drop internal tool builder",
     tags: ["UI", "Database", "Editor"],
   },
+  {
+    name: "Hoppscotch",
+    imageSrc: "https://avatars.githubusercontent.com/u/56705483?v=4",
+    projectLink: "https://github.com/hoppscotch/hoppscotch/contribute",
+    description:
+      "Hoppscotch is an open-source API development ecosystem.",
+    tags: ["TypeScript", "API", "Developer Tools", "GraphQL"],
+  },
 
   {
     name: "Hamilton",


### PR DESCRIPTION
## Summary
- add Hoppscotch to the project suggestions list
- link to Hoppscotch contributors through GitHub /contribute
- include the project avatar and relevant API/developer-tool tags

## Validation
- verified the Hoppscotch project entry is unique in src/data/projects.js
- verified https://github.com/hoppscotch/hoppscotch/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Hoppscotch has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Hoppscotch card/link

Addresses #1
