### PR TITLE
[codex] add PostHog to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1403,6 +1403,14 @@ export const projectList = [
     ],
   },
   {
+    name: "PostHog",
+    imageSrc: "https://avatars.githubusercontent.com/u/60330232?v=4",
+    projectLink: "https://github.com/PostHog/posthog/contribute",
+    description:
+      "PostHog is an open-source product analytics platform for building better products.",
+    tags: ["Python", "TypeScript", "Analytics", "Product"],
+  },
+  {
     name: "MeiliSearch",
     imageSrc: "https://avatars.githubusercontent.com/u/43250847?s=200&v=4",
     projectLink: "https://github.com/meilisearch/meilisearch",


### PR DESCRIPTION
## Summary
- add PostHog to the project suggestions list
- link to PostHog contributors through GitHub /contribute
- include the project avatar and relevant analytics/product tags

## Validation
- verified the PostHog project entry is unique in src/data/projects.js
- verified https://github.com/PostHog/posthog/contribute returns 200
- verified the project avatar returns 200 image/png
- verified PostHog has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered PostHog card/link

Addresses #1
