### PR TITLE
[codex] add Directus to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -61,6 +61,14 @@ export const projectList = [
     description: "Drag & Drop internal tool builder",
     tags: ["UI", "Database", "Editor"],
   },
+  {
+    name: "Directus",
+    imageSrc: "https://avatars.githubusercontent.com/u/15967950?v=4",
+    projectLink: "https://github.com/directus/directus/contribute",
+    description:
+      "Directus is an open-source data platform for managing SQL databases with APIs.",
+    tags: ["TypeScript", "CMS", "API", "Database"],
+  },
 
   {
     name: "Hamilton",


### PR DESCRIPTION
## Summary
- add Directus to the project suggestions list
- link to Directus contributors through GitHub /contribute
- include the project avatar and relevant data-platform tags

## Validation
- verified the Directus project entry is unique in src/data/projects.js
- verified https://github.com/directus/directus/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Directus has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Directus card/link

Addresses #1
