### PR TITLE
[codex] add Appwrite to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -61,6 +61,14 @@ export const projectList = [
     description: "Drag & Drop internal tool builder",
     tags: ["UI", "Database", "Editor"],
   },
+  {
+    name: "Appwrite",
+    imageSrc: "https://avatars.githubusercontent.com/u/25003669?v=4",
+    projectLink: "https://github.com/appwrite/appwrite/contribute",
+    description:
+      "Appwrite is an open-source backend platform for building web, mobile, and server applications.",
+    tags: ["Backend", "API", "Developer Tools", "Self Hosted"],
+  },
 
   {
     name: "Hamilton",


### PR DESCRIPTION
## Summary
- add Appwrite to the project suggestions list
- link to Appwrite contributors through GitHub /contribute
- include the project avatar and relevant backend/API tags

## Validation
- verified the Appwrite project entry is unique in src/data/projects.js
- verified https://github.com/appwrite/appwrite/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Appwrite has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Appwrite card/link

Addresses #1
