### PR TITLE
[codex] add Chatwoot to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1445,6 +1445,14 @@ export const projectList = [
     tags: ["Go", "React", "Chat", "Collaboration"],
   },
   {
+    name: "Chatwoot",
+    imageSrc: "https://avatars.githubusercontent.com/u/23416667?v=4",
+    projectLink: "https://github.com/chatwoot/chatwoot/contribute",
+    description:
+      "Chatwoot is an open-source customer engagement suite for support teams.",
+    tags: ["Ruby", "Rails", "Chat", "Customer Support"],
+  },
+  {
     name: "Terraform",
     imageSrc: "https://avatars.githubusercontent.com/u/11051457?s=200&v=4",
     projectLink: "https://github.com/hashicorp/terraform",


### PR DESCRIPTION
## Summary
- add Chatwoot to the project suggestions list
- link to Chatwoot contributors through GitHub /contribute
- include the project avatar and relevant chat/support tags

## Validation
- verified the Chatwoot project entry is unique in src/data/projects.js
- verified https://github.com/chatwoot/chatwoot/contribute returns 200
- verified the project avatar returns 200 image/png
- verified Chatwoot has open good first issue items
- ran git diff --check
- ran GITHUB_TOKEN=$(gh auth token) pnpm build
- checked dist/index.html contains the rendered Chatwoot card/link

Addresses #1
