### PR TITLE
[codex] add Flagsmith to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -61,6 +61,14 @@ export const projectList = [
     description: "Drag & Drop internal tool builder",
     tags: ["UI", "Database", "Editor"],
   },
+  {
+    name: "Flagsmith",
+    imageSrc: "https://avatars.githubusercontent.com/u/58150233?v=4",
+    projectLink: "https://github.com/Flagsmith/flagsmith/contribute",
+    description:
+      "Flagsmith is an open-source feature flag and remote config service.",
+    tags: ["Python", "Feature Flags", "DevOps", "API"],
+  },
 
   {
     name: "Hamilton",


### PR DESCRIPTION
## What changed
- Added Flagsmith to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one Flagsmith row in `src/data/projects.js`.
- Verified `https://github.com/Flagsmith/flagsmith/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/58150233?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `Flagsmith/flagsmith`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the Flagsmith card and link.

Addresses #1.
