### PR TITLE
[codex] add ToolJet to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1452,6 +1452,14 @@ export const projectList = [
     tags: ["Go", "Infrastructure as Code", "DevOps", "Cloud"],
   },
   {
+    name: "ToolJet",
+    imageSrc: "https://avatars.githubusercontent.com/u/82193554?v=4",
+    projectLink: "https://github.com/ToolJet/ToolJet/contribute",
+    description:
+      "ToolJet is an open-source platform for building internal tools, dashboards, workflows, and AI agents.",
+    tags: ["TypeScript", "JavaScript", "Internal Tools", "Low Code"],
+  },
+  {
     name: "Ansible",
     imageSrc: "https://avatars.githubusercontent.com/u/1507452?s=200&v=4",
     projectLink: "https://github.com/ansible/ansible",


### PR DESCRIPTION
## What changed
- Added ToolJet to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one ToolJet row in `src/data/projects.js`.
- Verified `https://github.com/ToolJet/ToolJet/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/82193554?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `ToolJet/ToolJet`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the ToolJet card and link.

Addresses #1.
