### PR TITLE
[codex] add OpenRefine to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -36,6 +36,14 @@ export const projectList = [
     tags: ["design", "opensourcedesign", "open-source", "open-source-design"],
   },
   {
+    name: "OpenRefine",
+    imageSrc: "https://avatars.githubusercontent.com/u/2538880?v=4",
+    projectLink: "https://github.com/OpenRefine/OpenRefine/contribute",
+    description:
+      "OpenRefine is an open-source tool for cleaning, transforming, and improving messy data.",
+    tags: ["Java", "Data Cleaning", "Data Analysis", "Open Data"],
+  },
+  {
     name: "Open Source Diversity",
     imageSrc: "https://avatars1.githubusercontent.com/u/31018274?s=200&v=4",
     projectLink:


### PR DESCRIPTION
## What changed
- Added OpenRefine to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one OpenRefine row in `src/data/projects.js`.
- Verified `https://github.com/OpenRefine/OpenRefine/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/2538880?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `OpenRefine/OpenRefine`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the OpenRefine card and link.

Addresses #1.
