### PR TITLE
[codex] add MapLibre GL JS to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1445,6 +1445,14 @@ export const projectList = [
     tags: ["Go", "React", "Chat", "Collaboration"],
   },
   {
+    name: "MapLibre GL JS",
+    imageSrc: "https://avatars.githubusercontent.com/u/75709127?v=4",
+    projectLink: "https://github.com/maplibre/maplibre-gl-js/contribute",
+    description:
+      "MapLibre GL JS is an open-source JavaScript library for interactive vector maps in the browser.",
+    tags: ["JavaScript", "TypeScript", "Maps", "WebGL"],
+  },
+  {
     name: "Terraform",
     imageSrc: "https://avatars.githubusercontent.com/u/11051457?s=200&v=4",
     projectLink: "https://github.com/hashicorp/terraform",


### PR DESCRIPTION
## What changed
- Added MapLibre GL JS to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one MapLibre GL JS row in `src/data/projects.js`.
- Verified `https://github.com/maplibre/maplibre-gl-js/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/75709127?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `maplibre/maplibre-gl-js`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the MapLibre GL JS card and link.

Addresses #1.
