### PR TITLE
[codex] add Penpot to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -390,6 +390,14 @@ export const projectList = [
     tags: ["Dart", "Mobile", "Cross Platform"],
   },
   {
+    name: "Penpot",
+    imageSrc: "https://avatars.githubusercontent.com/u/30179644?v=4",
+    projectLink: "https://github.com/penpot/penpot/contribute",
+    description:
+      "Penpot is an open-source design and prototyping platform for product teams.",
+    tags: ["Clojure", "ClojureScript", "Design", "Prototyping"],
+  },
+  {
     name: "Python Koans",
     imageSrc:
       "https://s3.amazonaws.com/media-p.slid.es/thumbnails/akoebbe/b35d77/python-koans.jpg",


### PR DESCRIPTION
## What changed
- Added Penpot to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one Penpot row in `src/data/projects.js`.
- Verified `https://github.com/penpot/penpot/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/30179644?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `penpot/penpot`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the Penpot card and link.

Addresses #1.
