### PR TITLE
[codex] add GitHub Desktop to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -432,6 +432,14 @@ export const projectList = [
     tags: ["JavaScript", "Electron", "Desktop", "Cross Platform"],
   },
   {
+    name: "GitHub Desktop",
+    imageSrc: "https://avatars.githubusercontent.com/u/13171334?v=4",
+    projectLink: "https://github.com/desktop/desktop/contribute",
+    description:
+      "GitHub Desktop is an open-source app for working with Git and GitHub from your desktop.",
+    tags: ["TypeScript", "Electron", "Git", "Desktop"],
+  },
+  {
     name: "Oppia",
     imageSrc:
       "https://www.oppia.org/build/assets/images/logo/288x128_logo_mint.42f8d38467fe745205b3374b33668068.png",


### PR DESCRIPTION
## What changed
- Added GitHub Desktop to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one GitHub Desktop row in `src/data/projects.js`.
- Verified `https://github.com/desktop/desktop/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/13171334?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `desktop/desktop`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the GitHub Desktop card and link.

Addresses #1.
