### PR TITLE
[codex] add DBeaver to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1078,6 +1078,13 @@ export const projectList = [
     tags: ["OpenSource", "Mariadb", "Mysql", "HTML", "PHP", "Javascript"],
   },
   {
+    name: "DBeaver",
+    imageSrc: "https://avatars.githubusercontent.com/u/34743864?v=4",
+    projectLink: "https://github.com/dbeaver/dbeaver/contribute",
+    description: "DBeaver is a free universal database tool and SQL client.",
+    tags: ["Java", "SQL", "Database", "Desktop"],
+  },
+  {
     name: "Litefy",
     imageSrc:
       "https://raw.githubusercontent.com/mathkruger/litefy/master/src/assets/logo.png",


### PR DESCRIPTION
## What changed
- Added DBeaver to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one DBeaver row in `src/data/projects.js`.
- Verified `https://github.com/dbeaver/dbeaver/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/34743864?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `dbeaver/dbeaver`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the DBeaver card and link.

Addresses #1.
