### PR TITLE
[codex] add Metabase to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -997,6 +997,14 @@ export const projectList = [
     ],
   },
   {
+    name: "Metabase",
+    imageSrc: "https://avatars.githubusercontent.com/u/10520629?v=4",
+    projectLink: "https://github.com/metabase/metabase/contribute",
+    description:
+      "Metabase is an open-source business intelligence and embedded analytics tool.",
+    tags: ["Clojure", "Business Intelligence", "Analytics", "Data"],
+  },
+  {
     name: "Mattermost",
     imageSrc:
       "https://raw.githubusercontent.com/mattermost/mattermost-handbook/3b54c2cd1f823d1ea012ce45d1baa61fb4fbedbc/.gitbook/assets/branding/logo-downloads/mattermost-logo-vertical-blue.png",


### PR DESCRIPTION
## What changed
- Added Metabase to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one Metabase row in `src/data/projects.js`.
- Verified `https://github.com/metabase/metabase/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/10520629?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `metabase/metabase`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the Metabase card and link.

Addresses #1.
