### PR TITLE
[codex] add Node-RED to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -331,6 +331,14 @@ export const projectList = [
     tags: ["JavaScript", "Node.js", "Runtime"],
   },
   {
+    name: "Node-RED",
+    imageSrc: "https://avatars.githubusercontent.com/u/5375661?v=4",
+    projectLink: "https://github.com/node-red/node-red/contribute",
+    description:
+      "Node-RED is a low-code programming tool for event-driven applications.",
+    tags: ["JavaScript", "Node.js", "Low Code", "IoT"],
+  },
+  {
     name: "Semantic-UI-React",
     imageSrc: "https://reactnative.dev/img/header_logo.svg",
     projectLink: "https://github.com/Semantic-Org/Semantic-UI-React/contribute",


### PR DESCRIPTION
## What changed
- Added Node-RED to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one Node-RED row in `src/data/projects.js`.
- Verified `https://github.com/node-red/node-red/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/5375661?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `node-red/node-red`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the Node-RED card and link.

Addresses #1.
