### PR TITLE
[codex] add WordPress Gutenberg to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -324,6 +324,14 @@ export const projectList = [
     tags: ["JavaScript", "Education", "Web Development"],
   },
   {
+    name: "WordPress Gutenberg",
+    imageSrc: "https://avatars.githubusercontent.com/u/276006?v=4",
+    projectLink: "https://github.com/WordPress/gutenberg/contribute",
+    description:
+      "Gutenberg is the WordPress block editor project for building and publishing web content.",
+    tags: ["JavaScript", "React", "WordPress", "Editor"],
+  },
+  {
     name: "Node.js",
     imageSrc: "https://avatars1.githubusercontent.com/u/9950313?v=3&s=100",
     projectLink: "https://github.com/nodejs/node/contribute",


### PR DESCRIPTION
## What changed
- Added WordPress Gutenberg to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one WordPress Gutenberg row in `src/data/projects.js`.
- Verified `https://github.com/WordPress/gutenberg/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/276006?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `WordPress/gutenberg`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the WordPress Gutenberg card and link.

Addresses #1.
