### PR TITLE
[codex] add Apache Superset to project suggestions

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1403,6 +1403,14 @@ export const projectList = [
     ],
   },
   {
+    name: "Apache Superset",
+    imageSrc: "https://avatars.githubusercontent.com/u/47359?v=4",
+    projectLink: "https://github.com/apache/superset/contribute",
+    description:
+      "Apache Superset is an open-source data visualization and exploration platform.",
+    tags: ["Python", "Data Visualization", "Analytics", "BI"],
+  },
+  {
     name: "MeiliSearch",
     imageSrc: "https://avatars.githubusercontent.com/u/43250847?s=200&v=4",
     projectLink: "https://github.com/meilisearch/meilisearch",


### PR DESCRIPTION
## What changed
- Added Apache Superset to the project suggestions list.
- Uses the upstream GitHub avatar and `/contribute` page so new contributors land on GitHub's curated beginner-issue view.

## Validation
- Verified there is exactly one Apache Superset row in `src/data/projects.js`.
- Verified `https://github.com/apache/superset/contribute` returns 200.
- Verified `https://avatars.githubusercontent.com/u/47359?v=4` returns 200 `image/png`.
- Verified open `good first issue` items exist in `apache/superset`.
- Ran `git diff --check`.
- Ran `GITHUB_TOKEN=$(gh auth token) pnpm build`.
- Verified the rendered homepage contains the Apache Superset card and link.

Addresses #1.
