### PR TITLE
[codex] add rel to issue preview links

### DIFF
--- a/src/components/IssueList.astro
+++ b/src/components/IssueList.astro
@@ -120,7 +120,7 @@ if (repoInfo) {
   {issues.length > 0 ? (
     <div class="Issues-List">
       {issues.map((issue) => (
-        <a href={issue.html_url} target="_blank" class="Issue-Card">
+        <a href={issue.html_url} target="_blank" rel="noopener noreferrer" class="Issue-Card">
           <div class="Issue-Content">
             <div class="Issue-Title">{issue.title}</div>
             <div class="Issue-Meta">


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to issue preview links that open in a new tab
- keep the issue preview fetch and rendering behavior unchanged

## Why
This closes a small best-practices/security gap in the project issue previews: the links already use `target="_blank"`, so they should also declare the relationship attributes.

Related to #347.

## Validation
- `git diff --check`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`