### PR TITLE
[codex] label tag filter select

### DIFF
--- a/src/components/ProjectList.astro
+++ b/src/components/ProjectList.astro
@@ -17,7 +17,7 @@ const allTags = [...new Set(projectList.flatMap(project => project.tags || []))]
     />
   </div>
   <div id="tag-selector-container" class="inputContainer">
-    <select id="tag-selector" aria-labelledby="tag-selector-container">
+    <select id="tag-selector" aria-label="Filter by tags">
       <option value="">Filter by tags</option>
       {allTags.map(tag => (
         <option value={tag.toLowerCase()}>{tag}</option>


### PR DESCRIPTION
## Summary
- replace the tag filter select wrapper reference with a direct accessible label
- keep the visible filter UI and filtering behavior unchanged

## Why
The select was using `aria-labelledby="tag-selector-container"`, but that points at the generic wrapper around the control instead of a clear label. A direct `aria-label` gives assistive tech a stable name for the tag filter.

Related to #501 and #347.

## Validation
- `git diff --check`
- `GITHUB_TOKEN=$(gh auth token) pnpm build`