### PR TITLE
[codex] use HTTPS code of conduct links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,7 +62,7 @@ separately.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [http://contributor-covenant.org/version/1/4][version]
+available at [https://www.contributor-covenant.org/version/1/4/][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+[homepage]: https://www.contributor-covenant.org/
+[version]: https://www.contributor-covenant.org/version/1/4/


### PR DESCRIPTION
## Summary
- update Contributor Covenant attribution links from `http` to `https`
- use the canonical `www.contributor-covenant.org` host for the homepage and version URL

## Why
This removes insecure Code of Conduct references and avoids redirect hops for readers.

Related to #347.

## Validation
- `git diff --check`
- `curl -I -L https://www.contributor-covenant.org/`
- `curl -I -L https://www.contributor-covenant.org/version/1/4/`