### PR TITLE
frontend(feat): add Payload Components to project list

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -61,6 +61,22 @@ export const projectList = [
     description: "Drag & Drop internal tool builder",
     tags: ["UI", "Database", "Editor"],
   },
+  {
+    name: "Payload Components",
+    imageSrc: "https://avatars.githubusercontent.com/u/58126222?v=4",
+    projectLink: "https://github.com/Ducksss/payload-components/contribute",
+    description:
+      "MIT registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects.",
+    loadIssues: true,
+    tags: [
+      "TypeScript",
+      "Next.js",
+      "React",
+      "Payload CMS",
+      "shadcn",
+      "Tailwind CSS",
+    ],
+  },
 
   {
     name: "Hamilton",


### PR DESCRIPTION
## Summary
- Add Payload Components to the beginner-friendly project list.
- Point the project card to GitHub's `/contribute` view.
- Enable live issue loading for beginner labels.

## Rationale
Payload Components is an MIT registry and CLI for installing wired Payload CMS blocks into Payload v3 and Next.js projects. Adding it to the catalog gives beginners another active TypeScript/Next.js/Payload project to discover.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm build`
