### PR TITLE
docs: fix outdated run instructions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ where `<github_username>` is your GitHub username.
 Here you're copying the contents of your firstcontributions.github.io repository on GitHub to your computer.
 
 ## Running The Project
-You should have [yarn](https://yarnpkg.com/en/docs/install) and [node](https://nodejs.org/en/download/) to run the project locally.
+You should have [node](https://nodejs.org/en/download/) (v18+) and npm (or [pnpm](https://pnpm.io/installation)) to run the project locally.
 
 Change to the repository directory on your computer (if you are not already there):
 ```
@@ -31,14 +31,13 @@ cd firstcontributions.github.io
 
 Then install the required Dependencies using:
 ```
- yarn install
+npm install
 ```
 
 *If you run into a dependencies issue, try removing `node_modules`.*
 
 After installation, run:
 ```
-yarn start
+npm run dev
 ```
-Now you can open your cloned project at ` http://localhost:3000/
-`
+Now you can open your cloned project at `http://localhost:4321/`


### PR DESCRIPTION
## What
`CONTRIBUTING.md` still instructs new contributors to run `yarn install` and `yarn start`, but the project has migrated to **Astro** and uses npm/pnpm.

## Why this is a problem
- There is **no `start` script** in `package.json` (the scripts are `dev`, `build`, `preview`), so `yarn start` fails on a fresh clone — the first thing a new contributor tries.
- The docs point to `http://localhost:3000/`, but Astro's dev server runs on **4321**.

## Changes
- Install: `yarn install` → `npm install`
- Run: `yarn start` → `npm run dev`
- Local URL: `localhost:3000` → `localhost:4321`
- Dropped the now-unnecessary yarn prerequisite.

This matches the current `package.json` and `README.md`, so new contributors can get the project running on their first try.