### PR TITLE
Add AgentPack to project list

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1,5 +1,22 @@
 export const projectList = [
   {
+    name: "AgentPack",
+    imageSrc: "https://avatars.githubusercontent.com/u/37480057?v=4",
+    projectLink: "https://github.com/vishal2612200/agentpack",
+    description:
+      "Context engine and CLI toolkit for AI coding agents, with beginner-friendly issues for docs, Python, CLI, testing, and benchmarks.",
+    loadIssues: true,
+    tags: [
+      "Python",
+      "CLI",
+      "Developer Tools",
+      "AI Coding Agents",
+      "Good First Issue",
+      "Testing",
+      "Documentation",
+    ],
+  },
+  {
     name: "activist.org",
     imageSrc:
       "https://raw.githubusercontent.com/activist-org/Organization/main/logos/activistLogoRounded.png",

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -12,6 +12,7 @@ export const projectList = [
       "Developer Tools",
       "AI Coding Agents",
       "Good First Issue",
+      "First Timers Only",
       "Testing",
       "Documentation",
     ],


### PR DESCRIPTION
## Summary

Adds AgentPack to the project discovery list so new contributors can find its beginner-friendly Python, CLI, docs, testing, and benchmark issues.

## Validation

- `NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc pnpm install --frozen-lockfile`
- `NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc pnpm approve-builds --all`
- `NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc pnpm build`