### PR TITLE
Add OpenAPI Generator to project list

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1458,4 +1458,11 @@ export const projectList = [
     description: "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
     tags: ["Python", "Automation", "Configuration Management"],
   },
+  {
+  name: "OpenAPI Generator",
+  imageSrc: "https://avatars.githubusercontent.com/u/37385255?s=200&v=4",
+  projectLink: "https://github.com/OpenAPITools/openapi-generator/issues",
+  description: "Generate API clients, server stubs, documentation, and configuration from OpenAPI specifications.",
+  tags: ["Java", "OpenAPI", "REST API", "Code Generation", "Backend"],
+  },
 ];


### PR DESCRIPTION
### Summary
Added OpenAPI Generator to the project suggestions list.

### Changes
- Added OpenAPI Generator project details to `src/data/projects.js`.
- Added project image, project/issues link, description, and relevant tags.
- Tested locally and confirmed the project card is visible and the link opens correctly.

### Issue
Addresses #1