### PR TITLE
Add AI Language Partner to project list

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1458,4 +1458,23 @@ export const projectList = [
     description: "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
     tags: ["Python", "Automation", "Configuration Management"],
   },
+  {
+    name: "AI Language Partner",
+    imageSrc: "https://avatars.githubusercontent.com/u/280634153?s=200&v=4",
+    projectLink: "https://github.com/duct-tape2/ai-language-partner",
+    description:
+      "Local-first Japanese speaking practice for Korean learners with browser-friendly language review, documentation, accessibility, API, and test issues.",
+    loadIssues: true,
+    tags: [
+      "TypeScript",
+      "Python",
+      "React Native",
+      "FastAPI",
+      "Education",
+      "Japanese",
+      "Korean",
+      "Accessibility",
+      "Good First Issue",
+    ],
+  },
 ];


### PR DESCRIPTION
### Summary

Adds AI Language Partner to the project discovery list. It is an active MIT-licensed local-first Japanese learning app for Korean speakers with browser-friendly docs and language-review tasks plus TypeScript, Python, React Native, FastAPI, accessibility, API, and test issues.

- Repository: https://github.com/duct-tape2/ai-language-partner
- Contributor entry: https://github.com/duct-tape2/ai-language-partner/contribute
- 52 open starter issues with `good first issue` / `help wanted` labels
- Live issue loading enabled in the project card

### Verification

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `git diff --check`

Addresses #1

Started in https://github.com/firstcontributions/firstcontributions.github.io/issues/1#issuecomment-4931220251