### PR TITLE
Add .env.example for token setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GITHUB_TOKEN=your_token_here


### PR DESCRIPTION
Adds a .env.example file to show the expected format for GITHUB_TOKEN, since it's referenced in the README setup instructions but no example file currently exists.