### PR TITLE
Add MemWhale project

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1458,4 +1458,14 @@ export const projectList = [
     description: "Ansible is a radically simple IT automation platform that makes your applications and systems easier to deploy.",
     tags: ["Python", "Automation", "Configuration Management"],
   },
+  {
+    name: "MemWhale",
+    imageSrc:
+      "https://raw.githubusercontent.com/wuisabel-gif/MemWhale/main/assets/memorywhale-logo-sm.png",
+    projectLink: "https://github.com/wuisabel-gif/MemWhale",
+    description:
+      "Persistent, local memory for developers and their coding agents. Records commands, output, errors, and the fixes that worked into SQLite and serves them over MCP.",
+    loadIssues: true,
+    tags: ["Rust", "TypeScript", "Python", "SQLite", "MCP", "Developer Tools"],
+  },
 ];


### PR DESCRIPTION
Adds **MemWhale** to the project list — persistent, local memory for developers and their coding agents. It records commands, output, errors, and the fixes that worked into SQLite and serves them over MCP (Rust core, TypeScript dashboard, Python integrations).

**Why it's a good fit for first-timers:**
- Public repo with issues enabled and `loadIssues: true`, so open issues surface on the card.
- Currently has issues labeled `good first issue`, including a docs-only one and a small Rust feature:
  - wuisabel-gif/MemWhale#90 — Add a Zed editor integration (docs, copy an existing integration folder)
  - wuisabel-gif/MemWhale#91 — Expose a standalone `mw explain <id>` command (small Rust feature, plumbing already exists)

Entry appended at the end of `src/data/projects.js`, matching the existing format. Logo URL verified reachable.