### PR TITLE
Fix 'Go to Project' button link by separating IssueList from outer an…

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -37,13 +37,15 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
       <div class="Card-Description">
         <p>{description}</p>
       </div>
-      {loadIssues && (
-        <IssueList projectLink={projectLink} projectName={name} />
-      )}
     </div>
-    <div class="Card-Link">
-      <span>Go to Project</span>
+  </a>
+  {loadIssues && (
+    <div class="Card-Issues-Wrapper">
+      <IssueList projectLink={projectLink} projectName={name} />
     </div>
+  )}
+  <a class="Card-Link" href={projectLink} target="_blank">
+    <span>Go to Project</span>
   </a>
 </div>
 
@@ -60,6 +62,8 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     min-height: 200px;
     margin-bottom: 1.5rem;
     position: relative;
+    display: flex;
+    flex-direction: column;
   }
 
   .Card-Container::before {
@@ -87,10 +91,8 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
   }
 
   .Card-Real-Link {
-    display: block;
     text-decoration: none;
     color: inherit;
-    height: 100%;
     display: flex;
     flex-direction: column;
     position: relative;
@@ -155,8 +157,16 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     margin: 0;
   }
 
+  .Card-Issues-Wrapper {
+    padding: 0 1.5rem 1rem;
+    position: relative;
+    z-index: 2;
+  }
 
   .Card-Link {
+    display: block;
+    text-decoration: none;
+    cursor: pointer;
     background: linear-gradient(135deg, rgba(102, 126, 234, 0.8) 0%, rgba(118, 75, 162, 0.8) 100%);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
@@ -170,6 +180,7 @@ const { projectLink, logoLink, name, description, tags = [], loadIssues = false 
     transition: all 0.3s ease;
     position: relative;
     overflow: hidden;
+    z-index: 2;
   }
 
   .Card-Link::before {


### PR DESCRIPTION
### 🐛 Problem Description
On project cards that have `loadIssues: true` enabled (`activist.org`, `CircuitVerse`, and `Opensourcedesign`), hovering over or clicking the "Go to Project" button did not work as a link and did not display a pointer cursor (`cursor: pointer`).

### 🔍 Root Cause Analysis
In `src/components/ProjectCard.astro`, the entire project card was wrapped in a top-level anchor tag (`<a class="Card-Real-Link">`). When `loadIssues: true` is enabled, `<IssueList />` renders individual GitHub issue links using `<a>` tags inside the card body.

According to HTML specifications, nesting `<a>` tags inside `<a>` tags is invalid HTML. Browser DOM parsers automatically auto-closed the parent `<a class="Card-Real-Link">` before rendering the inner issue links. This ejected `<div class="Card-Link"><span>Go to Project</span></div>` outside of the anchor element in the DOM tree, causing it to lose its hyperlink functionality and pointer cursor styling.

### 🛠️ Changes Made
- Refactored `src/components/ProjectCard.astro`:
  - Wrapped header, tags, and description in `<a class="Card-Real-Link" href={projectLink} target="_blank">`.
  - Moved `{loadIssues && <IssueList />}` into `<div class="Card-Issues-Wrapper">`, rendering it outside of any parent `<a>` element.
  - Converted the "Go to Project" button into an explicit anchor tag: `<a class="Card-Link" href={projectLink} target="_blank">`.
  - Updated CSS styles to preserve original layout, hover transitions, and `cursor: pointer` behavior.

### ✅ Verification
- Verified DOM structure has no invalid nested `<a>` tags.
- Verified that "Go to Project" button displays `cursor: pointer` and opens project link when clicked on cards with `loadIssues: true`.
- Verified issue links inside `<IssueList />` remain independently clickable.