### PR TITLE
fix: correct Aprenda Go project link

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1297,10 +1297,9 @@ export const projectList = [
   },
   {
     name: "aprenda-go-com-testes",
-    projectLink: "https://github.com/larien/aprenda-go-com-testes",
+    projectLink: "https://github.com/cassio645/aprenda-go-com-testes",
     imageSrc:
       "https://raw.githubusercontent.com/larien/aprenda-go-com-testes/refs/heads/main/.gitbook/assets/red-green-blue-gophers-smaller.png",
-    projectLink: "https://github.com/cassio645/aprenda-go-com-testes",
     description: "learn easily and quickly",
     tags: ["go"],
   },


### PR DESCRIPTION
## What changed

- Fixed the incorrect project link for `aprenda-go-com-testes`
- Removed the duplicate `projectLink` property

## Testing

- `pnpm install`
- `pnpm build`

Build completed successfully.

Fixes #347